### PR TITLE
fix: Use exampleSite as a working-directory for pages copy

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -60,6 +60,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
+        working-directory: exampleSite
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./public


### PR DESCRIPTION
## Description

Use exampleSite as a working directory for the deploy job.

## Pre-launch Checklist

- [x] I read the contribution guidelines. 
- [x] I signed-off my commit.
- [x] I updated/added relevant documentation.


