### PR TITLE
feat: Add homepage and links to placeholder content

### DIFF
--- a/assets/scss/_buttons.scss
+++ b/assets/scss/_buttons.scss
@@ -1,0 +1,56 @@
+// Default button style
+.button {
+  display: inline-block;
+  padding: 10px 20px;
+  border-radius: 47px;
+  background-color: var(--ospo-primary-700);
+  color: var(--white);
+  text-transform: uppercase;
+  text-decoration: none;
+  line-height: 1;
+  text-align: center;
+  letter-spacing: 0.7px;
+
+  &:hover,
+  &:active {
+    color: var(--white);
+    background-color: var(--ospo-primary-800);
+  }
+  &.secondary {
+    background-color: var(--ospo-primary-500);
+    &:hover,
+    &:active {
+      color: var(--white);
+      background-color: var(--ospo-primary-700);
+    }
+  }
+  &.tertiary {
+    background-color: var(--ospo-primary-500);
+    &:hover {
+      color: var(--white);
+      background-color: var(--ospo-primary-700);
+    }
+    &:active {
+      color: var(--black);
+      background-color: var(--white);
+    }
+  }
+}
+
+.button {
+  margin-top: 30px;
+  margin-bottom: 30px;
+  @media (min-width: $min-desktop) {
+    margin-top: 50px;
+    margin-bottom: 50px;
+  }
+}
+
+.button + .button {
+  margin-top: 0;
+  margin-bottom: 30px;
+  @media (min-width: $min-desktop) {
+    margin-top: 0;
+    margin-bottom: 50px;
+  }
+}

--- a/assets/scss/_footer.scss
+++ b/assets/scss/_footer.scss
@@ -5,8 +5,8 @@
   @media (min-width: $min-desktop) {
     padding-top: 100px;
   }
-  background-color: var(--footer-bg-color);
-  color: var(--footer-link-color);
+  background-color: var(--ospo-footer-bg-color);
+  color: var(--ospo-footer-link-color);
 
   // Reset lists.
   ul {

--- a/assets/scss/_global.scss
+++ b/assets/scss/_global.scss
@@ -1,56 +1,56 @@
 body {
-	overscroll-behavior: none; // fixes menu off bottom of screen.
-	height: auto;
-	max-width: 100%;
-	display: flex;
-	flex-direction: column;
-	min-height: 100vh;
-	@supports (min-height: 100dvh) {
-		min-height: 100dvh;
-	}
-	&.has-menu-active {
-		// Stops backround moving when menu open.
-		overflow: hidden;
-		height: 100%;
-	}
+  overscroll-behavior: none; // fixes menu off bottom of screen.
+  height: auto;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  @supports (min-height: 100dvh) {
+    min-height: 100dvh;
+  }
+  &.has-menu-active {
+    // Stops backround moving when menu open.
+    overflow: hidden;
+    height: 100%;
+  }
 }
 
 footer {
-	margin-top: auto;
+  margin-top: auto;
 }
 
 .container {
-	margin: auto;
-	width: 100%;
-	max-width: 100%;
-	@media (min-width: $desktop-width) {
-		max-width: var(--container-width);
-	}
+  margin: auto;
+  width: 100%;
+  max-width: 100%;
+  @media (min-width: $desktop-width) {
+    max-width: var(--ospo-container-width);
+  }
 }
 
 .wrap {
-	padding-left: 12px;
-	padding-right: 12px;
+  padding-left: 12px;
+  padding-right: 12px;
 
-	@media (min-width: 372px) {
-		padding-left: var(--gutter);
-		padding-right: var(--gutter);
-	}
+  @media (min-width: 372px) {
+    padding-left: var(--ospo-gutter);
+    padding-right: var(--ospo-gutter);
+  }
 
-	@media (min-width: $desktop-width) {
-		padding-left: 0px;
-		padding-right: 0px;
-	}
+  @media (min-width: $desktop-width) {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
 }
 
 // Reusable.
 .ul-reset {
-	list-style-type: none;
-	margin-block-start: 0;
-	margin-block-end: 0;
-	margin-inline-start: 0;
-	margin-inline-end: 0;
-	li {
-		margin-bottom: 0;
-	}
+  list-style-type: none;
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  li {
+    margin-bottom: 0;
+  }
 }

--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -1,79 +1,87 @@
-.header { 
-    width: 100%; 
-    background: var($primary); // TODO: review variable and color usage ss
-    z-index: 20;
+.header {
+  width: 100%;
+  background: var($primary); // TODO: review variable and color usage ss
+  z-index: 20;
 
-    position: relative;
-    &.sticky {
-        position: sticky;
-        
-        // no sticky header on small screens
-        // TODO: review viewport definition and consider variable usage
-        @media (min-width: 515px) and (max-height: 615px) {
-            position: relative;
-        }
-        top: 0;
-        left:0;
-        right:0;
-    }
-    &:after {
-        content: "";
-        position: absolute;
-        top: 100%;
-        width: 100%;
-        height: 20px;
-        z-index: 10;
-        background: linear-gradient(180deg, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0) 100%);
-        @media (min-width: $min-desktop) {
-            background: linear-gradient(180deg, rgba(0, 0, 0, 0.05) 0%, rgba(0, 0, 0, 0) 100%);
-        }
-    }
+  position: relative;
+  &.sticky {
+    position: sticky;
 
-    > .container {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-        align-content: center;
-        height: 60px;
-        @media (min-width: $min-desktop) {
-            height: 80px;
-        }
+    // no sticky header on small screens
+    // TODO: review viewport definition and consider variable usage
+    @media (min-width: 515px) and (max-height: 615px) {
+      position: relative;
     }
+    top: 0;
+    left: 0;
+    right: 0;
+  }
+  &:after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    width: 100%;
+    height: 20px;
+    z-index: 10;
+    background: linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.1) 0%,
+      rgba(0, 0, 0, 0) 100%
+    );
+    @media (min-width: $min-desktop) {
+      background: linear-gradient(
+        180deg,
+        rgba(0, 0, 0, 0.05) 0%,
+        rgba(0, 0, 0, 0) 100%
+      );
+    }
+  }
 
-    // Reset lists.
-    ul {
-        @extend .ul-reset;
+  > .container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    align-content: center;
+    height: 60px;
+    @media (min-width: $min-desktop) {
+      height: 80px;
     }
+  }
 
-    .logo {
-        object-position: 0 0;
-        object-fit: contain;
-        max-width: 100px;
-        max-height: 40px;
-        @media (min-width: $min-desktop) {
-            max-width: 130px;
-            max-height: 50px;
-        }
-    }
+  // Reset lists.
+  ul {
+    @extend .ul-reset;
+  }
 
-    .logo-link {
-        display: inline-flex;
+  .logo {
+    object-position: 0 0;
+    object-fit: contain;
+    max-width: 100px;
+    max-height: 40px;
+    @media (min-width: $min-desktop) {
+      max-width: 130px;
+      max-height: 50px;
     }
+  }
 
-    .site-title-link {
-        text-decoration: none;
-        color: var(--primary-400);
-        text-transform: uppercase;
-        font-family: var($logo-font);
-        font-weight: 700;
-        font-size: 20px;
-        @media (min-width: $min-desktop) {
-            flex-shrink: 0;
-            font-size: 22px;
-        }
-        @media (min-width: $desktop-width) {
-            font-size: 28px;
-        }
+  .logo-link {
+    display: inline-flex;
+  }
+
+  .site-title-link {
+    text-decoration: none;
+    color: var(--primary-400);
+    text-transform: uppercase;
+    font-family: var(--ospo-title-font-family);
+    font-weight: 700;
+    font-size: 20px;
+    @media (min-width: $min-desktop) {
+      flex-shrink: 0;
+      font-size: 22px;
     }
+    @media (min-width: $desktop-width) {
+      font-size: 28px;
+    }
+  }
 }

--- a/assets/scss/_typography.scss
+++ b/assets/scss/_typography.scss
@@ -1,0 +1,37 @@
+// General rules of typography that apply across the whole website.
+// Set body size.
+body {
+  font-size: 0.875em; // 14px.
+  @media (min-width: 500px) {
+    font-size: 1em; // 16px.
+  }
+  font-weight: 400;
+  color: var(--ospo-text-color);
+  font-family: var(--ospo-body-font-family);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.title {
+  font-family: var(--ospo-title-font-family);
+  margin-block-start: 70px;
+  margin-block-end: 50px;
+  @media (min-width: $desktop-width) {
+    margin-block-start: 100px;
+    margin-block-end: 80px;
+  }
+}
+
+h1,
+.h1 {
+  font-family: var(--ospo-title-font-family);
+  font-weight: 700;
+  color: var(--black);
+  text-transform: uppercase;
+  line-height: 112.2%;
+  font-size: 44px;
+  @media (min-width: $min-desktop) {
+    line-height: 115%;
+    font-size: 80px;
+  }
+}

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -7,15 +7,27 @@ $desktop-width: calc(1200px + 25px + 25px) !default;
 $min-desktop: 1000px !default;
 $mobile-max: 999px !default;
 
-$primary: #FFFFFF;
-$logo-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji' !default;
+$primary: #ffffff;
+
+$font-family: system-ui, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif,
+  "Apple Color Emoji", "Segoe UI Emoji" !default;
 
 //  CSS custom properties
 :root {
-    --gutter: 25px;
-    --container-width: 1200px;
-    --footer-bg-color: white;
-    --footer-link-color: black;
-    --footer-link-color-hover: grey;
-    --color-bg-subtle: #f6f8fa;
-  }
+  --white: white;
+  --black: black;
+  /* Typography */
+  --ospo-body-font-family: $font-family;
+  --ospo-title-font-family: $font-family;
+  --ospo-button-font-family: $font-family;
+
+  --ospo-text-color: black;
+  --ospo-primary-400: #bdbdbd;
+  --ospo-primary-500: #9e9e9e;
+  --ospo-primary-700: #616161;
+  --ospo-primary-800: #424242;
+  --ospo-gutter: 25px;
+  --ospo-container-width: 1200px;
+  --ospo-footer-bg-color: white;
+  --ospo-footer-link-color: black;
+}

--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -3,5 +3,7 @@
 
 @import "normalize";
 @import "global";
+@import "typography";
 @import "header";
 @import "footer";
+@import "buttons";

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -1,1 +1,11 @@
-Welcome!
+---
+title: ospo theme demo
+---
+
+This is an example site for the ospo theme. This theme has been created for the Hugo CMS, and has been developed and released by ospo.ch.
+
+{{< button link="catalog" text="Software Catalog" >}}
+
+{{< button link="projects" style="secondary" text="Projects" >}}
+
+{{< button link="monitor" style="tertiary" text="Monitor" >}}

--- a/exampleSite/content/catalog/_index.md
+++ b/exampleSite/content/catalog/_index.md
@@ -1,0 +1,3 @@
+---
+title: Software Catalog
+---

--- a/exampleSite/content/monitor/_index.md
+++ b/exampleSite/content/monitor/_index.md
@@ -1,0 +1,3 @@
+---
+title: monitor
+---

--- a/exampleSite/content/projects/_index.md
+++ b/exampleSite/content/projects/_index.md
@@ -1,0 +1,3 @@
+---
+title: projects
+---

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,13 +1,19 @@
 <!DOCTYPE html>
-<html lang="{{ or site.Language.LanguageCode }}" dir="{{ or site.Language.LanguageDirection `ltr` }}">
-<head>
-  {{ partial "head.html" . }}
-</head>
-<body>
+<html
+  lang="{{ or site.Language.LanguageCode }}"
+  dir="{{ or site.Language.LanguageDirection `ltr` }}"
+>
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body>
     {{ partial "header.html" . }}
-  <main>
-    {{ block "main" . }}{{ end }}
-  </main>
+    <section class="container wrap">
+      <header>
+        <h1 class="title">{{ .Title }}</h1>
+      </header>
+      <main>{{ block "main" . }}{{ end }}</main>
+    </section>
     {{ partial "footer.html" . }}
-</body>
+  </body>
 </html>

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -1,7 +1,0 @@
-{{ define "main" }}
-  {{ .Content }}
-  {{ range site.RegularPages }}
-    <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-    {{ .Summary }}
-  {{ end }}
-{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,8 +1,6 @@
-{{ define "main" }}
-  <h1>{{ .Title }}</h1>
-  {{ .Content }}
-  {{ range .Pages }}
-    <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-    {{ .Summary }}
-  {{ end }}
-{{ end }}
+{{ define "main" }} {{ .Content }} {{ range .Pages }}
+<article>
+  <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+  <p>{{ .Summary }}</p>
+</article>
+{{ end }} {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,10 +1,1 @@
-{{ define "main" }}
-  <h1>{{ .Title }}</h1>
-
-  {{ $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}
-  {{ $dateHuman := .Date | time.Format ":date_long" }}
-  <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
-
-  {{ .Content }}
-  {{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}
-{{ end }}
+{{ define "main" }} {{ .Content }} {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,11 +1,11 @@
 <footer class="footer">
   <div class="container wrap">
     {{ with .Site.Params.ui.logo }}
-    <a class="logo-link" href="{{ "/" | absLangURL }}">
+    <a class="logo-link" href="{{ absLangURL "" }}">
         <img class="logo" width="150" height="40" src="{{ . | relURL }}" alt="{{ $.Site.Title | safeHTMLAttr }}">
     </a>
     {{ else }}
-    <a class="site-title-link" href="{{ "/" | absLangURL }}">
+    <a class="site-title-link" href="{{ absLangURL "" }}">
         <span class="site-title">{{ $.Site.Title }}</span>
     </a>
     {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,16 +1,15 @@
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title site.Title }}{{ end }}</title>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>
+  {{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title
+  site.Title }}{{ end }}
+</title>
 <meta name="description" content="{{ default .Summary .Description }}" />
 {{ if hugo.IsProduction -}}
-<meta name="robots" content="index, follow">
+<meta name="robots" content="index, follow" />
 {{ else -}}
-<meta name="robots" content="noindex, nofollow">
-{{ end -}}
-
-{{ partialCached "head/favicons.html" . }}
-{{ template "_internal/opengraph.html" . -}}
-{{ template "_internal/schema.html" . -}}
-{{ template "_internal/twitter_cards.html" . -}}
-{{ partialCached "head/css.html" . }}
-{{ partialCached "head/js.html" . }}
+<meta name="robots" content="noindex, nofollow" />
+{{ end -}} {{- partialCached "head/favicons.html" . }} {{- template
+"_internal/opengraph.html" . -}} {{- template "_internal/schema.html" . -}} {{-
+template "_internal/twitter_cards.html" . -}} {{- partialCached "head/css.html"
+. -}} {{- partialCached "head/js.html" . -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,11 +1,11 @@
 <header class="header">
     <div class="container wrap">
         {{ with .Site.Params.ui.logo }}
-        <a class="logo-link" href="{{ "/" | absLangURL }}">
+        <a class="logo-link" href="{{ absLangURL "" }}">
             <img class="logo" width="150" height="40" src="{{ . | relURL }}" alt="{{ $.Site.Title | safeHTMLAttr }}">
         </a>
         {{ else }}
-        <a class="site-title-link" href="{{ "/" | absLangURL }}">
+        <a class="site-title-link" href="{{ absLangURL "" }}">
             <span class="site-title">{{ $.Site.Title }}</span>
         </a>
         {{ end }}

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,0 +1,1 @@
+<a href="{{ .Get "link" | relLangURL }}" class="{{ with .Get "style" }}{{ if eq . "secondary" }}button secondary{{ else if eq . "tertiary" }}button tertiary{{ else }}button{{ end }}{{ else }}button{{ end }}">{{ .Get "text" }}</a>


### PR DESCRIPTION
## Description

This PR adds a landing page for the theme which contains 3 buttons to navigate towards:

- software catalog
- projects
- monitor

It also adds a <button> shortcode for styling (currently default to resolving the link path) - this should be reviewed. 

styles have been refactored to rely on CSS custom properties with an ospo prefix added. 

## Pre-launch Checklist

- [x] I read the contribution guidelines. 
- [x] I signed-off my commit.
- [x] I updated/added relevant documentation.


