### PR TITLE
feat: Add projects overview section

### DIFF
--- a/assets/scss/_cards.scss
+++ b/assets/scss/_cards.scss
@@ -43,15 +43,33 @@
     -webkit-box-orient: vertical;
   }
   &__links-container {
-    border-top: 1px solid #c4c4c4;
+    border-top: 1px solid #c4c4c44d;
     display: flex;
     flex-direction: row-reverse;
     justify-content: right;
     margin-top: 1.5rem;
     padding: 1rem 0;
   }
+
+  &__cta-link {
+    border-top: 1px solid #c4c4c44d;
+    margin-top: 3rem;
+    padding: 1rem 0;
+    justify-content: space-between;
+    align-items: center;
+    display: flex;
+  }
+
   &__link {
     padding-left: 2rem;
     text-decoration: none;
+  }
+
+  &__cover {
+    object-fit: cover;
+    aspect-ratio: calc(16 / 10);
+    margin-bottom: 1rem;
+    background: #c4c4c4;
+    overflow: hidden;
   }
 }

--- a/exampleSite/content/projects/_index.md
+++ b/exampleSite/content/projects/_index.md
@@ -1,3 +1,3 @@
 ---
-title: projects
+title: Projects
 ---

--- a/exampleSite/content/projects/awesome-codeswissgov.md
+++ b/exampleSite/content/projects/awesome-codeswissgov.md
@@ -1,0 +1,7 @@
+---
+title: codeswissgov
+description: A curated list of OSS by Swiss Authorities
+params:
+  org_name: ospo.ch
+  repository: https://github.com/ospo-ch/awesome-codeswissgov
+---

--- a/exampleSite/content/projects/ospo-hugo-theme.md
+++ b/exampleSite/content/projects/ospo-hugo-theme.md
@@ -1,0 +1,7 @@
+---
+title: ospo theme
+description: A theme for the Hugo CMS to launch an ospo
+params:
+  org_name: ospo.ch
+  repository: https://github.com/ospo-ch/ospo-hugo-theme
+---

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -1,0 +1,21 @@
+{{ define "main" }} {{ .Content }}
+<div class="cards columns-3">
+  {{ range .Pages }}
+  <div class="card">
+    <div class="card__cover"></div>
+    <div class="card__content">
+      <span class="card__lead">{{ .Params.org_name }}</span>
+      <h4 class="card__title">{{ .Title }}</h4>
+      <p class="card__description">{{ .Description }}</p>
+      <div class="card__cta-link">
+        <span>View Project</span>
+        <a href="{{ .Permalink }}" class="card__link">
+          <img loading="lazy" width="16" height="16" src="{{
+          "images/icons/arrow-right.svg" | relURL }}" alt="See details icon">
+        </a>
+      </div>
+    </div>
+  </div>
+  {{ end }}
+</div>
+{{ end }}


### PR DESCRIPTION
## Description

This PR adds the initial scaffolding for the project overview section. This section showcases a list of projects developed by the partner organizations.

<img width="1317" alt="Screenshot 2024-09-06 at 16 22 14" src="https://github.com/user-attachments/assets/aa3c0bcc-70fd-443a-ab0c-aab9cfa8d238">
