### PR TITLE
style: Use outline button style on the theme

### DIFF
--- a/assets/scss/_buttons.scss
+++ b/assets/scss/_buttons.scss
@@ -2,9 +2,7 @@
 .button {
   display: inline-block;
   padding: 10px 20px;
-  border-radius: var(--ospo-button-border-radius);
-  background-color: var(--ospo-button-background-color-primary);
-  color: var(--color-white);
+  border: 1px solid var(--ospo-button-border-color);
   text-transform: uppercase;
   text-decoration: none;
   line-height: 1;
@@ -13,27 +11,8 @@
 
   &:hover,
   &:active {
-    color: var(--ospo-button-color);
-    background-color: var(--ospo-button-highlight-background-color-primary);
-  }
-  &.secondary {
-    background-color: var(--ospo-button-background-color-secondary);
-    &:hover,
-    &:active {
-      color: var(--ospo-button-color);
-      background-color: var(--ospo-button-highlight-background-color-secondary);
-    }
-  }
-  &.tertiary {
-    background-color: var(--ospo-button-background-color-secondary);
-    &:hover {
-      color: var(--ospo-button-color);
-      background-color: var(--ospo-button-highlight-background-color-secondary);
-    }
-    &:active {
-      color: var(--color-black);
-      background-color: var(--color-white);
-    }
+    color: var(--ospo-button-highlight-color);
+    background-color: var(--ospo-button-highlight-background-color);
   }
 }
 

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -37,12 +37,10 @@ $font-family: system-ui, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif,
   --ospo-text-color: var(--color-black);
   --ospo-link-color: var(--color-gray-800);
   --ospo-link-highlight-color: var(--color-gray-700);
-  --ospo-button-background-color-primary: var(--color-gray-700);
-  --ospo-button-background-color-secondary: var(--color-gray-500);
-  --ospo-button-border-radius: 47px;
-  --ospo-button-color: var(--color-white);
-  --ospo-button-highlight-background-color-primary: var(--color-gray-800);
-  --ospo-button-highlight-background-color-secondary: var(--color-gray-700);
+  --ospo-button-background-color: var(--color-gray-700);
+  --ospo-button-border-color: var(--color-gray-500);
+  --ospo-button-highlight-color: var(--color-white);
+  --ospo-button-highlight-background-color: var(--color-gray-500);
   --ospo-gutter: 25px;
   --ospo-container-width: 1200px;
   --ospo-header-background-color: var(--color-white);

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -6,6 +6,6 @@ This is an example site for the ospo theme. This theme has been created for the 
 
 {{< button link="catalog" text="Software Catalog" >}}
 
-{{< button link="projects" style="secondary" text="Projects" >}}
+{{< button link="projects" text="Projects" >}}
 
-{{< button link="monitor" style="tertiary" text="Monitor" >}}
+{{< button link="monitor" text="Monitor" >}}

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,1 +1,1 @@
-<a href="{{ .Get "link" | relLangURL }}" class="{{ with .Get "style" }}{{ if eq . "secondary" }}button secondary{{ else if eq . "tertiary" }}button tertiary{{ else }}button{{ end }}{{ else }}button{{ end }}">{{ .Get "text" }}</a>
+<a href="{{ .Get "link" | absURL }}" class="{{ with .Get "style" }}button {{ . }}{{ else }}button{{ end }}">{{ .Get "text" }}</a>


### PR DESCRIPTION
## Description

This change remove secondary and tertiary button styles definition and rely on an outline style with squared borders for the button style.

Signed-off-by: Dimitri Kandassamy <dimitri.kandassamy@gmail.com>
