### PR TITLE
Bump hugo version in hugo.yml to use math.Pi

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.128.0
+      HUGO_VERSION: 0.130.0
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
## Description

math.Pi was introduced with Hugo 0.130.0, the gauge template relies on the math.Pi function for circumference calculation.
