### PR TITLE
chore: Bump Hugo min supported version to 0.130.0

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "A Hugo theme to bootstrap an ospo portal"
 homepage = "https://github.com/ospo-ch/ospo-hugo-theme/"
 tags = ["ospo", "multilingual", "responsive"]
 features = []
-min_version = "0.116.0"
+min_version = "0.130.0"
 
 [author]
-  name = "ospo.ch Authors"
+name = "ospo.ch Authors"


### PR DESCRIPTION
This theme uses math.Pi introduced in 0.130.0.

Signed-off-by: Dimitri Kandassamy <dimitri.kandassamy@gmail.com>
