### PR TITLE
style: Add color to docs-button to override safari default system color on button types

### DIFF
--- a/assets/scss/_docs.scss
+++ b/assets/scss/_docs.scss
@@ -199,6 +199,7 @@
   border-radius: var(--ospo-border-radius-medium);
   line-height: var(--ospo-font-icon-button-line-height);
   text-decoration: none;
+  color: var(--ospo-button-color);
   cursor: pointer;
 
   &:hover {

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -163,6 +163,7 @@ $font-weight-bold: 700 !default;
   --ospo-header-height: 3.75rem;
   --ospo-header-height-large: 5rem; // 80px
   --ospo-breadcrumb-divider: "/";
+  --ospo-button-color: var(--color-gray-800);
   --ospo-button-background-color: var(--color-gray-700);
   --ospo-button-border-color: var(--color-gray-500);
   --ospo-button-highlight-color: var(--color-white);


### PR DESCRIPTION
Signed-off-by: Dimitri Kandassamy <dimitri.kandassamy@gmail.com>
