### PR TITLE
Add documentation components

### DIFF
--- a/assets/scss/_code.scss
+++ b/assets/scss/_code.scss
@@ -5,6 +5,23 @@
 // Currently it's docs-wrapper which restricts those styles
 // to the documentation section of the theme.
 .docs-wrapper {
+  // Inline code
+  p code,
+  li > code,
+  table code {
+    color: inherit;
+    padding: 0.2em 0.4em;
+    margin: 0;
+    font-size: 85%;
+    word-break: normal;
+    background-color: var(--ospo-background-color-muted);
+    border-radius: var(--ospo-border-radius-medium);
+
+    br {
+      display: none;
+    }
+  }
+
   // Highlighted code.
   .highlight {
     margin: var(--ospo-spacing-2xl) var(--ospo-spacing-none);
@@ -14,9 +31,9 @@
     pre {
       margin: var(--ospo-spacing-none);
       padding: var(--ospo-spacing-lg);
+      font-size: 85%;
       background-color: var(--ospo-code-highlight-background-color);
-      border: var(--ospo-border-width-thin) solid
-        var(--ospo-code-highlight-border-color);
+      border: var(--ospo-border-width-thin) solid var(--ospo-border-color-muted);
       border-radius: var(--ospo-border-radius-medium);
     }
   }

--- a/assets/scss/_code.scss
+++ b/assets/scss/_code.scss
@@ -1,0 +1,19 @@
+// Code formatting
+
+.docs-wrapper {
+  // Highlighted code.
+  .highlight {
+    margin: var(--ospo-spacing-2xl) var(--ospo-spacing-none);
+    padding: var(--ospo-spacing-none);
+    position: relative;
+
+    pre {
+      margin: var(--ospo-spacing-none);
+      padding: var(--ospo-spacing-lg);
+      background-color: var(--ospo-code-highlight-background-color);
+      border: var(--ospo-border-width-thin) solid
+        var(--ospo-code-highlight-border-color);
+      border-radius: var(--ospo-border-radius-medium);
+    }
+  }
+}

--- a/assets/scss/_code.scss
+++ b/assets/scss/_code.scss
@@ -1,5 +1,9 @@
 // Code formatting
 
+// TODO: review the top level css container
+//
+// Currently it's docs-wrapper which restricts those styles
+// to the documentation section of the theme.
 .docs-wrapper {
   // Highlighted code.
   .highlight {

--- a/assets/scss/_docs.scss
+++ b/assets/scss/_docs.scss
@@ -1,5 +1,6 @@
 .docs-wrapper {
   display: flex;
+  word-wrap: break-word;
 }
 
 .docs-main {

--- a/assets/scss/_insights.scss
+++ b/assets/scss/_insights.scss
@@ -57,7 +57,7 @@
 
   &__score {
     font-weight: var(--ospo-font-weight-bold);
-    color: var(--color-gray-500);
+    color: var(--color-gray-600);
     width: 10%;
   }
 }

--- a/assets/scss/_syntax.scss
+++ b/assets/scss/_syntax.scss
@@ -2,6 +2,7 @@
 //
 // Currently it's docs-wrapper which restricts those styles
 // to the documentation section of the theme.
+
 .docs-wrapper {
   // Inline code
   p code,
@@ -54,9 +55,7 @@
     }
 
     // We want to keep table-layout: auto so that column widths dynamically adjust;
-    // otherwise entries get needlessly squashed into narrow columns. As a workaround,
-    // we use components/lib/wrap-code-terms.js to prevent some reference table content
-    // from expanding beyond the horizontal boundaries of the parent element.
+    // otherwise entries get needlessly squashed into narrow columns.
     @media (min-width: $screen-sm) {
       table-layout: auto;
     }
@@ -119,17 +118,8 @@
   }
 
   blockquote {
-    border-left: var(--ospo-border-width-thicker) solid
-      var(--ospo-border-color-muted);
-    margin: var(--ospo-spacing-lg) var(--ospo-spacing-none);
-    padding: var(--ospo-spacing-md) var(--ospo-spacing-lg);
-
     p {
       margin-top: var(--ospo-spacing-none);
-
-      &.alert-heading {
-        font-weight: var(--ospo-font-weight-medium);
-      }
     }
 
     p:last-child {
@@ -137,43 +127,35 @@
     }
   }
 
-  .alert-note {
-    border-left-color: blue;
+  .alert {
+    --ospo-alert-background-color: transparent;
+    --ospo-alert-border-color: var(--ospo-border-color-muted);
+    --ospo-alert-border-left: var(--ospo-border-width-thicker) solid
+      var(--ospo-alert-border-color);
+    --ospo-alert-padding-x: var(--ospo-spacing-lg);
+    --ospo-alert-padding-y: var(--ospo-spacing-md);
+    --ospo-alert-margin-x: var(--ospo-spacing-none);
+    --ospo-alert-margin-y: var(--ospo-spacing-lg);
 
-    .alert-heading {
-      color: blue;
-    }
+    background-color: var(--ospo-alert-background-color);
+    border-left: var(--ospo-alert-border-left);
+    margin: var(--ospo-alert-margin-y) var(--ospo-alert-margin-x);
+    padding: var(--ospo-alert-padding-y) var(--ospo-alert-padding-x);
   }
 
-  .alert-tip {
-    border-left-color: green;
+  .alert-heading {
+    --ospo-alert-heading-font-weight: var(--ospo-font-weight-medium);
+    --ospo-alert-heading-color: inherit;
 
-    .alert-heading {
-      color: green;
-    }
+    color: var(--ospo-alert-heading-color);
+    font-weight: var(--ospo-alert-heading-font-weight);
   }
 
-  .alert-important {
-    border-left-color: darkorchid;
-
-    .alert-heading {
-      color: darkorchid;
-    }
-  }
-
-  .alert-warning {
-    border-left-color: darkgoldenrod;
-
-    .alert-heading {
-      color: darkgoldenrod;
-    }
-  }
-
-  .alert-caution {
-    border-left-color: darkred;
-
-    .alert-heading {
-      color: darkred;
+  // Generate contextual modifier classes for colorizing the alert heading and border
+  @each $type in map-keys($alert-types) {
+    .alert-#{$type} {
+      --ospo-alert-heading-color: var(--ospo-#{$type}-text-emphasis);
+      --ospo-alert-border-color: var(--ospo-#{$type}-border-subtle);
     }
   }
 }

--- a/assets/scss/_syntax.scss
+++ b/assets/scss/_syntax.scss
@@ -35,4 +35,86 @@
       border-radius: var(--ospo-border-radius-medium);
     }
   }
+
+  table {
+    display: table;
+    width: 100%;
+    font-size: var(--ospo-font-body-size-medium);
+    text-align: left;
+    table-layout: fixed;
+    border-collapse: collapse;
+    border-spacing: 0;
+
+    // For mobile (small viewports) we need to fix the table
+    // because if the table is larger than the viewport
+    // it will force the width of the table causing issues
+    // with the header on scroll
+    :not(:global(.has-nested-table)) & {
+      table-layout: fixed;
+    }
+
+    // We want to keep table-layout: auto so that column widths dynamically adjust;
+    // otherwise entries get needlessly squashed into narrow columns. As a workaround,
+    // we use components/lib/wrap-code-terms.js to prevent some reference table content
+    // from expanding beyond the horizontal boundaries of the parent element.
+    @media (min-width: $screen-sm) {
+      table-layout: auto;
+    }
+
+    // Remove zebra striping
+    tr:nth-child(2n) {
+      background-color: transparent;
+    }
+
+    // Make the header sticky
+    thead {
+      position: sticky;
+      top: calc(var(--ospo-header-height) + 1px);
+      background: var(--ospo-color-canvas-default);
+
+      @media (min-width: $screen-lg) {
+        top: calc(var(--ospo-header-height-large) + 1px) !important;
+      }
+    }
+
+    tr,
+    th,
+    td {
+      border: none;
+    }
+
+    thead th,
+    thead td {
+      box-shadow: inset 0 -2px var(--ospo-border-color-muted);
+    }
+
+    tbody th,
+    tbody td {
+      box-shadow: inset 0 -1px var(--ospo-border-color-muted);
+    }
+
+    tbody tr:last-child th,
+    tbody tr:last-child td {
+      box-shadow: none;
+    }
+
+    th,
+    td {
+      padding: var(--ospo-content-table-padding-vertical) var(--ospo-spacing-md);
+      vertical-align: top;
+    }
+
+    th:first-child,
+    td:first-child {
+      padding-left: var(--ospo-spacing-none);
+    }
+
+    pre {
+      margin-top: var(--ospo-spacing-xs);
+    }
+
+    p:last-child {
+      margin-bottom: var(--ospo-spacing-none);
+    }
+  }
 }

--- a/assets/scss/_syntax.scss
+++ b/assets/scss/_syntax.scss
@@ -118,6 +118,11 @@
   }
 
   blockquote {
+    border-left: var(--ospo-border-width-thicker) solid
+      var(--ospo-border-color-muted);
+    margin: var(--ospo-spacing-lg) var(--ospo-spacing-none);
+    padding: var(--ospo-spacing-md) var(--ospo-spacing-lg);
+
     p {
       margin-top: var(--ospo-spacing-none);
     }

--- a/assets/scss/_syntax.scss
+++ b/assets/scss/_syntax.scss
@@ -117,4 +117,63 @@
       margin-bottom: var(--ospo-spacing-none);
     }
   }
+
+  blockquote {
+    border-left: var(--ospo-border-width-thicker) solid
+      var(--ospo-border-color-muted);
+    margin: var(--ospo-spacing-lg) var(--ospo-spacing-none);
+    padding: var(--ospo-spacing-md) var(--ospo-spacing-lg);
+
+    p {
+      margin-top: var(--ospo-spacing-none);
+
+      &.alert-heading {
+        font-weight: var(--ospo-font-weight-medium);
+      }
+    }
+
+    p:last-child {
+      margin-bottom: var(--ospo-spacing-none);
+    }
+  }
+
+  .alert-note {
+    border-left-color: blue;
+
+    .alert-heading {
+      color: blue;
+    }
+  }
+
+  .alert-tip {
+    border-left-color: green;
+
+    .alert-heading {
+      color: green;
+    }
+  }
+
+  .alert-important {
+    border-left-color: darkorchid;
+
+    .alert-heading {
+      color: darkorchid;
+    }
+  }
+
+  .alert-warning {
+    border-left-color: darkgoldenrod;
+
+    .alert-heading {
+      color: darkgoldenrod;
+    }
+  }
+
+  .alert-caution {
+    border-left-color: darkred;
+
+    .alert-heading {
+      color: darkred;
+    }
+  }
 }

--- a/assets/scss/_syntax.scss
+++ b/assets/scss/_syntax.scss
@@ -1,5 +1,3 @@
-// Code formatting
-
 // TODO: review the top level css container
 //
 // Currently it's docs-wrapper which restricts those styles

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -162,7 +162,7 @@ $font-weight-bold: 700 !default;
   --ospo-icon-size-large: 2rem; // 32px
 
   /* Component variables */
-  --ospo-header-height: 3.75rem;
+  --ospo-header-height: 3.75rem; // 60 px
   --ospo-header-height-large: 5rem; // 80px
   --ospo-breadcrumb-divider: "/";
   --ospo-button-color: var(--color-gray-800);
@@ -221,6 +221,8 @@ $font-weight-bold: 700 !default;
     0.24
   ); // TODO: use base design token
   --ospo-background-color-muted: #afb8c133; // TODO: use base design token
+  --ospo-content-table-padding-vertical: calc(var(--ospo-spacing-xs) * 3);
+  --ospo-color-canvas-default: var(--color-white);
 
   /* z-index
   Keep this in order, and avoid reusing variables 

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -56,7 +56,8 @@ $font-weight-bold: 700 !default;
   --color-black: #000000;
   --color-gray-300: #e0e0e0;
   --color-gray-400: #bdbdbd;
-  --color-gray-500: #9e9e9e;
+  --color-gray-500: #d0d7de;
+  --color-gray-600: #9e9e9e;
   --color-gray-700: #616161;
   --color-gray-800: #424242;
   --color-green-700: #008800;
@@ -114,6 +115,7 @@ $font-weight-bold: 700 !default;
   --ospo-border-radius-medium: 0.375rem; // 6px
   --ospo-border-radius-large: 0.75rem; // 12px
   --ospo-border-color: var(--color-gray-400);
+  --ospo-border-color-muted: var(--color-gray-500);
 
   --ospo-outline-width-thin: max(1px, 0.0625rem);
 
@@ -165,9 +167,9 @@ $font-weight-bold: 700 !default;
   --ospo-breadcrumb-divider: "/";
   --ospo-button-color: var(--color-gray-800);
   --ospo-button-background-color: var(--color-gray-700);
-  --ospo-button-border-color: var(--color-gray-500);
+  --ospo-button-border-color: var(--color-gray-600);
   --ospo-button-highlight-color: var(--color-white);
-  --ospo-button-highlight-background-color: var(--color-gray-500);
+  --ospo-button-highlight-background-color: var(--color-gray-600);
   --ospo-card-animation-duration: 600ms;
   --ospo-card-animation-easing: cubic-bezier(0.16, 1, 0.3, 1);
   --ospo-card-background-color: var(--color-white);
@@ -202,7 +204,7 @@ $font-weight-bold: 700 !default;
   --ospo-header-background-color: var(--color-white);
   --ospo-link-color: var(--color-gray-800);
   --ospo-link-highlight-color: var(--color-gray-700);
-  --ospo-link-disabled-color: var(--color-gray-500);
+  --ospo-link-disabled-color: var(--color-gray-600);
   --ospo-menu-link-color: var(--color-black);
   --ospo-menu-link-color-hover: var(--color-gray-700);
   --ospo-progress-background-color: var(--color-gray-300);
@@ -212,7 +214,13 @@ $font-weight-bold: 700 !default;
   --ospo-score-container-padding: var(--ospo-spacing-md);
   --ospo-section-padding-vertical: calc(var(--ospo-spacing-md) * 6);
   --ospo-text-color: var(--color-black);
-  --ospo-color-background-hover: rgba(208, 215, 222, 0.24);
+  --ospo-color-background-hover: rgba(
+    208,
+    215,
+    222,
+    0.24
+  ); // TODO: use base design token
+  --ospo-background-color-muted: #afb8c133; // TODO: use base design token
 
   /* z-index
   Keep this in order, and avoid reusing variables 

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -49,6 +49,14 @@ $font-weight-medium: 500 !default;
 $font-weight-semibold: 600 !default;
 $font-weight-bold: 700 !default;
 
+$alert-types: (
+  "note": "accent",
+  "tip": "success",
+  "important": "upsell",
+  "warning": "attention",
+  "caution": "danger",
+) !default;
+
 //  CSS custom properties
 :root {
   /* Color Palette */
@@ -68,6 +76,12 @@ $font-weight-bold: 700 !default;
   --color-orange: #ffaa33;
   --color-red-700: #cc0000;
   --color-red: #ff3333;
+
+  --color-accent: #0969da;
+  --color-success: #1f883d;
+  --color-upsell: #8250df;
+  --color-attention: #9a6700;
+  --color-danger: #cf222e;
 
   /* Typography */
 
@@ -223,6 +237,12 @@ $font-weight-bold: 700 !default;
   --ospo-background-color-muted: #afb8c133; // TODO: use base design token
   --ospo-content-table-padding-vertical: calc(var(--ospo-spacing-xs) * 3);
   --ospo-color-canvas-default: var(--color-white);
+
+  /* Alerts Colors */
+  @each $type, $color in $alert-types {
+    --ospo-#{$type}-text-emphasis: var(--color-#{$color});
+    --ospo-#{$type}-border-subtle: var(--color-#{$color});
+  }
 
   /* z-index
   Keep this in order, and avoid reusing variables 

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -176,6 +176,8 @@ $font-weight-bold: 700 !default;
   --ospo-card-cta-wrapper-border-color: var(--color-gray-400);
   --ospo-card-kicker-color: var(--color-gray-800);
   --ospo-card-kicker-line-height: 2.6rem;
+  --ospo-code-highlight-border-color: #d0d7de;
+  --ospo-code-highlight-background-color: #f6f8fa;
   --ospo-color-insights-score-high: var(--color-green);
   --ospo-color-insights-score-high-secondary: var(--color-green-700);
   --ospo-color-insights-score-low: var(--color-red);

--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -17,4 +17,4 @@
 @import "catalog";
 @import "insights";
 @import "docs";
-@import "code";
+@import "syntax";

--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -17,3 +17,4 @@
 @import "catalog";
 @import "insights";
 @import "docs";
+@import "code";

--- a/exampleSite/content/en/docs/customization/writing-content.md
+++ b/exampleSite/content/en/docs/customization/writing-content.md
@@ -129,8 +129,20 @@ Example `[example](https://example.com)` will display the link [example](https:/
 | Column #1 |  Column #2  | Column #3 |
 | --------- | :---------: | --------: |
 | Item #1   | Property #1 |     $1600 |
-| Item #1   | Property #2 |       $12 |
-| Item #1   | Property #3 |        $1 |
+| Item #2   | Property #2 |       $12 |
+| Item #3   | Property #3 |        $1 |
+| Item #1   | Property #1 |     $1600 |
+| Item #2   | Property #2 |       $12 |
+| Item #3   | Property #3 |        $1 |
+| Item #1   | Property #1 |     $1600 |
+| Item #2   | Property #2 |       $12 |
+| Item #3   | Property #3 |        $1 |
+| Item #1   | Property #1 |     $1600 |
+| Item #2   | Property #2 |       $12 |
+| Item #3   | Property #3 |        $1 |
+| Item #1   | Property #1 |     $1600 |
+| Item #2   | Property #2 |       $12 |
+| Item #3   | Property #3 |        $1 |
 ```
 
 **Output**
@@ -138,8 +150,20 @@ Example `[example](https://example.com)` will display the link [example](https:/
 | Column #1 |  Column #2  | Column #3 |
 | --------- | :---------: | --------: |
 | Item #1   | Property #1 |     $1600 |
-| Item #1   | Property #2 |       $12 |
-| Item #1   | Property #3 |        $1 |
+| Item #2   | Property #2 |       $12 |
+| Item #3   | Property #3 |        $1 |
+| Item #1   | Property #1 |     $1600 |
+| Item #2   | Property #2 |       $12 |
+| Item #3   | Property #3 |        $1 |
+| Item #1   | Property #1 |     $1600 |
+| Item #2   | Property #2 |       $12 |
+| Item #3   | Property #3 |        $1 |
+| Item #1   | Property #1 |     $1600 |
+| Item #2   | Property #2 |       $12 |
+| Item #3   | Property #3 |        $1 |
+| Item #1   | Property #1 |     $1600 |
+| Item #2   | Property #2 |       $12 |
+| Item #3   | Property #3 |        $1 |
 
 ## Admonitions / Callouts
 

--- a/exampleSite/content/en/docs/customization/writing-content.md
+++ b/exampleSite/content/en/docs/customization/writing-content.md
@@ -7,10 +7,6 @@ weight: 5
 toc: true
 ---
 
-# Headers and Text
-
-Text, title, and styling in standard markdown
-
 ## Titles
 
 Best used for section headers.
@@ -24,3 +20,140 @@ Best used for section headers.
 ```text
 ### Subtitles
 ```
+
+## Text Formatting
+
+Bold style: use `**` around the text. `**bold**` will show as **bold**.
+
+Italic style: use `_` around the text. `_italic_` will show as _italic_.
+
+Strikethrough style: use `~` around the text. `~strikethrough~` will show as ~strikethrough~.
+
+## Links
+
+Example `[example](https://example.com)` will display the link [example](https://example.com).
+
+## Blockquotes
+
+### Singleline
+
+**Input**
+
+```text
+> This is a single line blockquote
+```
+
+**Output**
+
+> This is a single line blockquote
+
+### Multiline
+
+**Input**
+
+```text
+> This text will be shown on multiple lines.
+>
+> The end.
+```
+
+**Output**
+
+> This text will be shown on multiple lines.
+>
+> The end.
+
+## Lists
+
+### Ordered List
+
+**Input**
+
+```text
+1. First item
+2. Second item
+3. Third item
+4. Fourth item
+```
+
+**Output**
+
+1. First item
+2. Second item
+3. Third item
+4. Fourth item
+
+### Unordered List
+
+**Input**
+
+```text
+- First item
+- Second item
+- Third item
+- Fourth item
+```
+
+**Output**
+
+- First item
+- Second item
+- Third item
+- Fourth item
+
+### Nested List
+
+**Input**
+
+```text
+- First item
+- Second item
+  - Additional item
+  - Additional item
+- Third item
+```
+
+**Output**
+
+- First item
+- Second item
+  - Additional item
+  - Additional item
+- Third item
+
+### Tables
+
+**Input**
+
+```text
+| Column #1 |  Column #2  | Column #3 |
+| --------- | :---------: | --------: |
+| Item #1   | Property #1 |     $1600 |
+| Item #1   | Property #2 |       $12 |
+| Item #1   | Property #3 |        $1 |
+```
+
+**Output**
+
+| Column #1 |  Column #2  | Column #3 |
+| --------- | :---------: | --------: |
+| Item #1   | Property #1 |     $1600 |
+| Item #1   | Property #2 |       $12 |
+| Item #1   | Property #3 |        $1 |
+
+## Admonitions / Callouts
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.

--- a/exampleSite/content/en/docs/customization/writing-content.md
+++ b/exampleSite/content/en/docs/customization/writing-content.md
@@ -1,0 +1,8 @@
+---
+title: Writing Content
+linkTitle: Writing Content
+description: >
+  How to write content
+weight: 5
+toc: true
+---

--- a/exampleSite/content/en/docs/customization/writing-content.md
+++ b/exampleSite/content/en/docs/customization/writing-content.md
@@ -167,6 +167,27 @@ Example `[example](https://example.com)` will display the link [example](https:/
 
 ## Admonitions / Callouts
 
+**Input**
+
+```text
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+```
+
+**Output**
+
 > [!NOTE]
 > Useful information that users should know, even when skimming content.
 

--- a/exampleSite/content/en/docs/customization/writing-content.md
+++ b/exampleSite/content/en/docs/customization/writing-content.md
@@ -6,3 +6,21 @@ description: >
 weight: 5
 toc: true
 ---
+
+# Headers and Text
+
+Text, title, and styling in standard markdown
+
+## Titles
+
+Best used for section headers.
+
+```text
+## Titles
+```
+
+### Subtitles
+
+```text
+### Subtitles
+```

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -57,7 +57,7 @@ languages:
     languageCode: "en-US"
     weight: 1
     ### Copyright ###
-    copyright: "Copyright &copy; 2024. All Rights Reserved."
+    copyright: "Copyright &copy; 2024 - 2025. All Rights Reserved."
     params:
       ### Accessibility ###
       accessibility:
@@ -88,7 +88,7 @@ languages:
     languageName: "French"
     languageCode: "fr-FR"
     ### Copyright ###
-    copyright: "&copy; 2024 auteurs ospo.ch. Tous droits réservés."
+    copyright: "&copy; 2024 - 2025 auteurs ospo.ch. Tous droits réservés."
     weight: 2
     params:
       ### Accessibility ###

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -18,6 +18,16 @@ taxonomies:
   tag: "tags"
   languages: "languages"
 
+markup:
+  goldmark:
+    parser:
+      attribute:
+        block: true
+    renderer:
+      unsafe: true
+  highlight:
+    noClasses: false
+
 # UI configuration
 params:
   ui:

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -19,6 +19,23 @@ other = "On this page"
 [docs_sidebar_current_section]
 other = "In this section"
 
+# Alert 
+[alert_note]
+other = "Note"
+
+[alert_tip]
+other = "Tip"
+
+[alert_important]
+other = "Important"
+
+[alert_warning]
+other = "Warning"
+
+[alert_caution]
+other = "Caution"
+
+
 # Insights: Documentation 
 [insights_documentation_heading]
 other = "Documentation"
@@ -53,4 +70,3 @@ other = "Legal"
 
 [insights_legal_desc]
 other = "These checks ensure that your project is compliant with the legal guidelines."
-

--- a/layouts/_default/_markup/render-blockquote-alert.html
+++ b/layouts/_default/_markup/render-blockquote-alert.html
@@ -1,0 +1,10 @@
+<blockquote class="alert alert-{{ .AlertType }}">
+  <p class="alert-heading">
+    {{ with .AlertTitle }} 
+        {{ . }} 
+    {{ else }} 
+        {{ or (T (printf "alert_%s" .AlertType)) (title .AlertType) }} 
+    {{ end }}
+  </p>
+  {{ .Text }}
+</blockquote>

--- a/layouts/_default/markup/render-blockquote-alert.html
+++ b/layouts/_default/markup/render-blockquote-alert.html
@@ -1,0 +1,7 @@
+<blockquote class="alert alert-{{ .AlertType }}">
+  <p class="alert-heading">
+    {{ with .AlertTitle }} {{ . }} {{ else }} {{ or (T (printf "alert_%s"
+    .AlertType)) (title .AlertType) }} {{ end }}
+  </p>
+  {{ .Text }}
+</blockquote>


### PR DESCRIPTION
## Description

### Overview

This PR adds the documentation to write content using the `ospo-hugo-theme` as well as the markdown styles for: 

- [x] headings 
- [x] text formatting: bold, italic, strikethrough
- [x] single line and multi-line blockquotes 
- [x] lists (ordered, unordered, nested 
- [x] tables 
- [x] admonition/callouts/alerts

### Implementation details 

#### Tables

Tables are rendered with a `sticky header`.

<img width="833" alt="Screenshot 2025-01-23 at 17 58 50" src="https://github.com/user-attachments/assets/0b41143a-e039-4d47-a405-cfdb28ba9b3b" />

#### Admonitions

Admonitions uses the `/layouts/_default/_markup/render-blockquote-alert.html`as per [hugo documentation](https://gohugo.io/render-hooks/blockquotes/#alerts).

The default color scheme is borrowed from Github Primer without icon support. Styles can be customized via custom properties. A Sass variable `$alert-types` provides the mapping between the alert types and the color schemes. 

<img width="606" alt="Screenshot 2025-01-23 at 17 58 39" src="https://github.com/user-attachments/assets/a35c32ef-a939-4951-b52b-4f55db774725" />

#### TODO

Added TODO in the comments to be address in a future PR. Styles definitions are scoped within `docs-wrapper`, to be change at a later stage.

Signed-off-by: Dimitri Kandassamy <dimitri.kandassamy@gmail.com>