### PR TITLE
fix: alert rendering (bump hugo version)

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.130.0
+      HUGO_VERSION: 0.132.0
     steps:
       - name: Install Hugo CLI
         run: |

--- a/layouts/_default/markup/render-blockquote-alert.html
+++ b/layouts/_default/markup/render-blockquote-alert.html
@@ -1,7 +1,0 @@
-<blockquote class="alert alert-{{ .AlertType }}">
-  <p class="alert-heading">
-    {{ with .AlertTitle }} {{ . }} {{ else }} {{ or (T (printf "alert_%s"
-    .AlertType)) (title .AlertType) }} {{ end }}
-  </p>
-  {{ .Text }}
-</blockquote>

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "A Hugo theme to bootstrap an ospo portal"
 homepage = "https://github.com/ospo-ch/ospo-hugo-theme/"
 tags = ["ospo", "multilingual", "responsive"]
 features = []
-min_version = "0.130.0"
+min_version = "0.132.0"
 
 [author]
 name = "ospo.ch Authors"


### PR DESCRIPTION
## Description

This PR bumps the minimum hugo version required to `0.132.0` in order to support [render blockquote hooks](https://gohugo.io/render-hooks/blockquotes/#alerts).

- **chore: remove duplicate render hook**
- **build: bump min hugo version to 0.132.0 (support for render-blockquote hook)**
