### PR TITLE
build: Add module configuration (hugoVersion)

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,0 +1,8 @@
+# ospo-hugo-theme config
+#
+# documentation: https://gohugo.io/hugo-modules/configuration/
+
+module:
+  hugoVersion:
+    extended: true
+    min: 0.134.0


### PR DESCRIPTION
## Description

This PR adds the hugo module configuration for the `ospo-hugo-theme`,  see [docs](https://gohugo.io/hugo-modules/configuration/) for more information. 

Currently, it's used to specify the `hugoVersion` required for the theme. `0.134.0` is required to use the render blockquotes hook. 

Signed-off-by: Dimitri Kandassamy <dimitri.kandassamy@gmail.com>
