### PR TITLE
refactor: changes from code review

### DIFF
--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -1,21 +1,20 @@
-const accordions = document.querySelectorAll(".accordion");
-
 const openAccordion = (accordion) => {
-    accordion.classList.add("accordion__active");
+  accordion.classList.add("accordion__active");
 };
 
 const closeAccordion = (accordion) => {
-    accordion.classList.remove("accordion__active");
+  accordion.classList.remove("accordion__active");
 };
 
-accordions.forEach((accordion) => {
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".accordion").forEach((accordion) => {
     const title = accordion.querySelector(".accordion__title");
-
-    title.onclick = () => {
-        if (accordion.classList.contains("accordion__active")) {
-            closeAccordion(accordion);
-        } else {
-            openAccordion(accordion);
-        }
-    };
+    title.addEventListener("click", () => {
+      if (accordion.classList.contains("accordion__active")) {
+        closeAccordion(accordion);
+      } else {
+        openAccordion(accordion);
+      }
+    });
+  });
 });

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -313,6 +313,4 @@ Copyright (c) 2023 Cloud Native Computing Foundation (CNCF)
     // Apply dropdown listeners.
     applyDropdownListeners();
   });
-
-  console.log("script initialized ...");
 })();

--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -87,8 +87,8 @@
   };
 
   const handleEscapeKey = (e) => {
-    if (e.keyCode == 27) {
-      closeSidebar();
+    if (e.key === "Escape") {
+      closeSidebar(sidebar);
     }
   };
 

--- a/assets/scss/_accessibility.scss
+++ b/assets/scss/_accessibility.scss
@@ -39,6 +39,6 @@
     top: 5px;
     width: auto;
     z-index: var(--z-index-accessibility);
-    filter: drop-shadow(0 0 2px 2px rgba(0, 0, 0, 0.6));
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.6);
   }
 }

--- a/assets/scss/_docs.scss
+++ b/assets/scss/_docs.scss
@@ -71,8 +71,8 @@
 
   @media (min-width: $screen-lg) {
     position: sticky;
-    top: 81px;
-    height: 100vh -81px;
+    top: calc(var(--ospo-header-height-large) + var(--ospo-border-width-thin));
+    height: calc(100vh - var(--ospo-header-height-large) - var(--ospo-border-width-thin));
     overflow-y: auto;
   }
 }

--- a/assets/scss/_docs.scss
+++ b/assets/scss/_docs.scss
@@ -50,7 +50,23 @@
   }
 }
 
+.docs-nav-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: var(--color-black);
+  z-index: var(--z-index-docs-nav-backdrop);
+}
+
+.docs-nav-backdrop.show {
+  opacity: 0.5;
+}
+
 .docs-sidebar {
+  width: var(--ospo-size-width-medium);
+
   @media (max-width: $screen-lg) {
     position: fixed;
     top: 0;
@@ -75,24 +91,6 @@
     height: calc(100vh - var(--ospo-header-height-large) - var(--ospo-border-width-thin));
     overflow-y: auto;
   }
-}
-
-.docs-nav-backdrop {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: var(--color-black);
-  z-index: var(--z-index-docs-nav-backdrop);
-}
-
-.docs-nav-backdrop.show {
-  opacity: 0.5;
-}
-
-.docs-sidebar {
-  width: var(--ospo-size-width-medium);
 
   &__header {
     flex: none;

--- a/assets/scss/_typography.scss
+++ b/assets/scss/_typography.scss
@@ -14,55 +14,55 @@ body {
 
 h1,
 .h1 {
-  font-size: var(--h1-size-mobile, $h1-size-mobile) !important;
+  font-size: var(--h1-size-mobile, $h1-size-mobile);
 
   @media (min-width: $screen-md) {
-    font-size: var(--h1-size, $h1-size) !important;
+    font-size: var(--h1-size, $h1-size);
   }
 }
 
 h2,
 .h2 {
-  font-size: var(--h2-size-mobile, $h2-size-mobile) !important;
+  font-size: var(--h2-size-mobile, $h2-size-mobile);
 
   @media (min-width: $screen-md) {
-    font-size: var(--h2-size, $h2-size) !important;
+    font-size: var(--h2-size, $h2-size);
   }
 }
 
 h3,
 .h3 {
-  font-size: var(--h3-size-mobile, $h3-size-mobile) !important;
+  font-size: var(--h3-size-mobile, $h3-size-mobile);
 
   @media (min-width: $screen-md) {
-    font-size: var(--h3-size, $h3-size) !important;
+    font-size: var(--h3-size, $h3-size);
   }
 }
 
 h4,
 .h4 {
-  font-size: var(--h4-size-mobile, $h4-size-mobile) !important;
+  font-size: var(--h4-size-mobile, $h4-size-mobile);
 
   @media (min-width: $screen-md) {
-    font-size: var(--h4-size, $h4-size) !important;
+    font-size: var(--h4-size, $h4-size);
   }
 }
 
 h5,
 .h5 {
-  font-size: var(--h5-size-mobile, $h5-size-mobile) !important;
+  font-size: var(--h5-size-mobile, $h5-size-mobile);
 
   @media (min-width: $screen-md) {
-    font-size: var(--h5-size, $h5-size) !important;
+    font-size: var(--h5-size, $h5-size);
   }
 }
 
 h6,
 .h6 {
-  font-size: var(--h6-size-mobile, $h6-size-mobile) !important;
+  font-size: var(--h6-size-mobile, $h6-size-mobile);
 
   @media (min-width: $screen-md) {
-    font-size: var(--h6-size, $h6-size) !important;
+    font-size: var(--h6-size, $h6-size);
   }
 }
 
@@ -73,7 +73,7 @@ h6,
 .h5,
 .h6 {
   font-family: var(--ospo-font-family-heading);
-  font-weight: var(--ospo-font-weight-heading) !important;
+  font-weight: var(--ospo-font-weight-heading);
 }
 
 p + p,

--- a/debug.sh
+++ b/debug.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 # https://coderwall.com/p/fkfaqq/safer-bash-scripts-with-set-euxo-pipefail
-#
-# set -e will cause the script to exit immediately when a command fails
-set -e 
+set -euo pipefail
 
 cd exampleSite && hugo server --gc --themesDir=../.. --logLevel debug

--- a/exampleSite/content/en/insights/ospo-theme.md
+++ b/exampleSite/content/en/insights/ospo-theme.md
@@ -8,7 +8,7 @@ params:
     aggregate: 63
     documentation: 70
     license: 75
-    practices: 26
+    best_practices: 26
     security: 45
     legal: 100
 ---

--- a/exampleSite/content/en/insights/ospo-utils.md
+++ b/exampleSite/content/en/insights/ospo-utils.md
@@ -8,7 +8,7 @@ params:
     aggregate: 100
     documentation: 100
     license: 100
-    practices: 100
+    best_practices: 100
     security: 100
     legal: 100
 ---

--- a/exampleSite/content/en/insights/project-template.md
+++ b/exampleSite/content/en/insights/project-template.md
@@ -8,7 +8,7 @@ params:
     aggregate: 28
     documentation: 50
     license: 25
-    practices: 15
+    best_practices: 15
     security: 40
     legal: 10
   repositories:

--- a/exampleSite/content/fr/insights/ospo-theme.md
+++ b/exampleSite/content/fr/insights/ospo-theme.md
@@ -8,7 +8,7 @@ params:
     aggregate: 63
     documentation: 70
     license: 75
-    practices: 26
+    best_practices: 26
     security: 45
     legal: 100
 ---

--- a/exampleSite/content/fr/insights/ospo-utils.md
+++ b/exampleSite/content/fr/insights/ospo-utils.md
@@ -8,7 +8,7 @@ params:
     aggregate: 100
     documentation: 100
     license: 100
-    practices: 100
+    best_practices: 100
     security: 100
     legal: 100
 ---

--- a/exampleSite/content/fr/insights/project-template.md
+++ b/exampleSite/content/fr/insights/project-template.md
@@ -8,7 +8,7 @@ params:
     aggregate: 28
     documentation: 50
     license: 25
-    practices: 15
+    best_practices: 15
     security: 40
     legal: 10
   repositories:

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,14 +7,14 @@
     {{- partial "head.html" . -}}
   </head>
   <body>
-    {{- partialCached "accessibility.html" . -}} 
-    {{- partialCached "header.html" . -}}
+    {{- partialCached "accessibility.html" . "global" -}}
+    {{- partialCached "header.html" . .Language.Lang -}}
     <section id="content" class="container wrap">
       <header>
         <h1>{{ .Title }}</h1>
       </header>
       <main>{{ block "main" . }}{{ end }}</main>
     </section>
-    {{- partialCached "footer.html" . -}}
+    {{- partialCached "footer.html" . "global" -}}
   </body>
 </html>

--- a/layouts/catalog/list.html
+++ b/layouts/catalog/list.html
@@ -14,12 +14,13 @@
             href="{{ .Params.repository }}"
             class="card__action"
             target="_blank"
+            rel="noopener noreferrer"
           >
             <img loading="lazy" width="16" height="16" src="{{
             "images/icons/repository.svg" | relURL }}" alt="Source repository
             icon">
           </a>
-          <a href="{{ .Params.website }}" class="card__action" target="_blank">
+          <a href="{{ .Params.website }}" class="card__action" target="_blank" rel="noopener noreferrer">
             <img loading="lazy" width="16" height="16" src="{{
             "images/icons/up-right-from-square.svg" | relURL }}" alt="Go to
             website icon">

--- a/layouts/catalog/single.html
+++ b/layouts/catalog/single.html
@@ -2,7 +2,7 @@
 <div class="main-wrapper">
   <div class="main-area">
     <article>
-      <p>{{- .Content -}}</p>
+      {{- .Content -}}
     </article>
   </div>
   <hr />

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -7,8 +7,8 @@
     {{- partial "head.html" . -}}
   </head>
   <body>
-    {{- partialCached "accessibility.html" . -}} 
-    {{- partialCached "header.html" . -}}
+    {{- partialCached "accessibility.html" . "global" -}}
+    {{- partialCached "header.html" . .Language.Lang -}}
     <div class="container-fluid docs-wrapper">
       <aside class="sidebar">
         <div class="docs-nav-container">
@@ -49,6 +49,6 @@
     {{ $js := resources.Get "js/accordion.js" }}
     <script defer src="{{ $js.Permalink }}"></script>
 
-    {{ partial "scripts.html" . }}
+    {{- partialCached "scripts.html" . "global" -}}
   </body>
 </html>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -33,4 +33,4 @@
   </div>
 </footer>
 
-{{ partialCached "scripts.html" . }}
+{{- partialCached "scripts.html" . "global" -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,7 +21,7 @@
           <ul class="social-links">
             {{ range . }}
             <li>
-                <a href="{{ .url }}" title="">
+                <a href="{{ .url }}" aria-label="{{ humanize .key }}" rel="noopener noreferrer" target="_blank">
                     <img loading="lazy" width="20" height="20" src="{{ printf "images/icons/%s.svg" .key | relURL }}" alt="{{ (humanize .key) | safeHTMLAttr }} icon">
                 </a>
             </li>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,8 +13,8 @@
 {{- else -}}
   <meta name="robots" content="noindex, nofollow" />
 {{ end -}} 
-{{- partialCached "head/favicons.html" . -}} 
-{{- template "_internal/opengraph.html" . -}} 
-{{- template "_internal/schema.html" . -}} 
-{{- template "_internal/twitter_cards.html" . -}} 
-{{- partialCached "head/css.html" . -}}
+{{- partialCached "head/favicons.html" . "global" -}}
+{{- template "_internal/opengraph.html" . -}}
+{{- template "_internal/schema.html" . -}}
+{{- template "_internal/twitter_cards.html" . -}}
+{{- partialCached "head/css.html" . "global" -}}

--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -16,6 +16,6 @@
 {{ else }}
     {{ $options = merge $options (dict "outputStyle" "nested" "enableSourceMap" true) }}
 {{ end }}
-{{ $style := resources.Get $source | css.Sass $options | css.PostCSS (dict "config" "postcss.config.js") | resources.Minify | resources.Fingerprint "sha512" }}
+{{ $style := resources.Get $source | css.Sass $options | css.PostCSS (dict "config" "postcss.config.js") | resources.Fingerprint "sha512" }}
 <link rel="preload" href="{{ $style.RelPermalink }}" as="style">
 <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" media="all">

--- a/layouts/partials/insights/category-summary.html
+++ b/layouts/partials/insights/category-summary.html
@@ -1,7 +1,7 @@
 {{ $categories := slice 
   (dict "key" "insights_documentation" "score" .Params.score.documentation) 
   (dict "key" "insights_license" "score" .Params.score.license) 
-  (dict "key" "insights_best_practices" "score" .Params.score.practices) 
+  (dict "key" "insights_best_practices" "score" .Params.score.best_practices)
   (dict "key" "insights_security" "score" .Params.score.security) 
   (dict "key" "insights_legal" "score" .Params.score.legal) 
 }}


### PR DESCRIPTION
## Description

- perf: fix partialCached variant keys so pages share a single cache entry
- fix: pass sidebar element to closeSidebar in Escape key handler
- fix: wrap docs sidebar height/top in calc() and replace magic 81px
- fix: remove \<p\> wrapper around .Content in catalog single layout
- fix: remove redundant resources.Minify from CSS pipeline
- fix: add rel="noopener noreferrer" to external target="_blank" links
- fix: replace empty title with aria-label on footer social links
- fix: replace invalid drop-shadow with box-shadow on skip link focus
- chore: remove console.log debug statement from menu.js
- fix: align score front matter key from practices to best_practices
- refactor: consolidate duplicate .docs-sidebar SCSS rule blocks
- fix: wrap accordion init in DOMContentLoaded and use addEventListener
- fix: add -u and -o pipefail to debug.sh set flags
- refactor: remove !important from heading font-size and font-weight rules



