### PR TITLE
feat: add documentation to example site (all locales) 

### DIFF
--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -1,17 +1,3 @@
-<<<<<<< HEAD
-const openAccordion = (accordion) => {
-  accordion.classList.add("accordion__active");
-};
-
-const closeAccordion = (accordion) => {
-  accordion.classList.remove("accordion__active");
-};
-
-document.addEventListener("DOMContentLoaded", () => {
-  document.querySelectorAll(".accordion").forEach((accordion) => {
-    const title = accordion.querySelector(".accordion__title");
-    title.addEventListener("click", () => {
-=======
 (function () {
   const accordions = document.querySelectorAll(".accordion");
 
@@ -30,18 +16,11 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     title.onclick = () => {
->>>>>>> 4ea927d (refactor: Scope accordion.js in an IIFE and guard missing title)
       if (accordion.classList.contains("accordion__active")) {
         closeAccordion(accordion);
       } else {
         openAccordion(accordion);
       }
-<<<<<<< HEAD
-    });
-  });
-});
-=======
     };
   });
 })();
->>>>>>> 4ea927d (refactor: Scope accordion.js in an IIFE and guard missing title)

--- a/exampleSite/content/en/_index.md
+++ b/exampleSite/content/en/_index.md
@@ -3,7 +3,7 @@ title: OSPO Theme Demo
 description: This is an example site for the ospo theme. This theme has been created for the Hugo CMS, and has been developed and released by ospo.ch.
 ---
 
-This is an example site for the ospo theme. This theme has been created for the Hugo CMS, and has been developed and released by ospo.ch.
+Explore our software catalog, active projects, and open source health reports. Built with the [OSPO Hugo Theme](https://github.com/ospo-ch/ospo-hugo-theme) — a ready-made portal for Open Source Program Offices.
 
 {{< button link="catalog" text="Software Catalog" >}}
 

--- a/exampleSite/content/en/catalog/_index.md
+++ b/exampleSite/content/en/catalog/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Software Catalog
 ---
+
+Browse the open source software maintained and used by ospo.ch. Each entry includes a description, licensing information, and links to the source repository.

--- a/exampleSite/content/en/catalog/catalog-001.md
+++ b/exampleSite/content/en/catalog/catalog-001.md
@@ -6,3 +6,7 @@ params:
   website: https://react.dev/
   repository: https://github.com/facebook/react
 ---
+
+React is a declarative, component-based JavaScript library for building user interfaces, maintained by Meta and a large open source community. It introduced the virtual DOM to minimize expensive real DOM updates, and popularized composing UIs from small, reusable components.
+
+React's unidirectional data flow and hooks API make it straightforward to manage state and side effects within components. It is widely used for single-page applications and can be rendered on the server via frameworks such as Next.js.

--- a/exampleSite/content/en/catalog/catalog-001.md
+++ b/exampleSite/content/en/catalog/catalog-001.md
@@ -1,6 +1,13 @@
 ---
 title: React
 description: A JavaScript library for building user interfaces.
+categories:
+  - frontend
+tags:
+  - javascript
+  - ui-library
+prog_languages:
+  - JavaScript
 params:
   org_name: Meta
   website: https://react.dev/

--- a/exampleSite/content/en/catalog/catalog-002.md
+++ b/exampleSite/content/en/catalog/catalog-002.md
@@ -6,3 +6,7 @@ params:
   website: https://vuejs.org/
   repository: https://github.com/vuejs/core
 ---
+
+Vue.js is a progressive JavaScript framework for building user interfaces. Unlike monolithic frameworks, Vue is designed to be incrementally adoptable — its core library focuses solely on the view layer, making it easy to integrate into existing projects or use as the foundation for a full-featured single-page application.
+
+Vue's reactivity system tracks dependencies automatically at the component level, and its single-file component (SFC) format collocates template, script, and style in one `.vue` file for maintainable authoring.

--- a/exampleSite/content/en/catalog/catalog-002.md
+++ b/exampleSite/content/en/catalog/catalog-002.md
@@ -1,6 +1,13 @@
 ---
 title: Vue.js
 description: A progressive, incrementally-adoptable JavaScript framework for building UI on the web.
+categories:
+  - frontend
+tags:
+  - javascript
+  - framework
+prog_languages:
+  - JavaScript
 params:
   org_name: Vue
   website: https://vuejs.org/

--- a/exampleSite/content/en/catalog/catalog-003.md
+++ b/exampleSite/content/en/catalog/catalog-003.md
@@ -6,7 +6,7 @@ categories:
 tags:
   - automation
   - deployment
-languages:
+prog_languages:
   - Python
 
 params:

--- a/exampleSite/content/en/catalog/catalog-004.md
+++ b/exampleSite/content/en/catalog/catalog-004.md
@@ -1,6 +1,13 @@
 ---
 title: Docker
 description: A collaborative project for the container ecosystem to assemble container-based systems.
+categories:
+  - devops
+tags:
+  - containers
+  - deployment
+prog_languages:
+  - Go
 params:
   org_name: Moby
   website: https://www.docker.com/

--- a/exampleSite/content/en/catalog/catalog-004.md
+++ b/exampleSite/content/en/catalog/catalog-004.md
@@ -6,3 +6,7 @@ params:
   website: https://www.docker.com/
   repository: https://github.com/moby/moby
 ---
+
+Docker is an open platform for developing, shipping, and running applications inside lightweight, portable containers. Containers package an application together with all its dependencies into a standardized unit, eliminating environment inconsistencies across development, staging, and production.
+
+The Moby project is the upstream open source component that Docker Engine is built from. It provides the daemon, CLI client, container runtime, image builder, and networking subsystems used by Docker Desktop and other container platforms.

--- a/exampleSite/content/en/catalog/catalog-005.md
+++ b/exampleSite/content/en/catalog/catalog-005.md
@@ -6,3 +6,7 @@ params:
   website: https://www.postgresql.org/
   repository: https://git.postgresql.org/gitweb/?p=postgresql.git
 ---
+
+PostgreSQL is a standards-compliant object-relational database system with over 35 years of active development. It offers full ACID compliance, complex queries, foreign keys, triggers, updatable views, transactional integrity, and multiversion concurrency control (MVCC).
+
+PostgreSQL runs on all major operating systems and supports a wide range of data types, indexing methods, and procedural languages. Its extensibility model allows users to define custom functions, operators, index types, and even new data types.

--- a/exampleSite/content/en/catalog/catalog-005.md
+++ b/exampleSite/content/en/catalog/catalog-005.md
@@ -1,6 +1,13 @@
 ---
 title: PostgreSQL
 description: A powerful, open source object-relational database system.
+categories:
+  - database
+tags:
+  - sql
+  - storage
+prog_languages:
+  - C
 params:
   org_name: PostgreSQL
   website: https://www.postgresql.org/

--- a/exampleSite/content/en/catalog/catalog-006.md
+++ b/exampleSite/content/en/catalog/catalog-006.md
@@ -6,3 +6,7 @@ params:
   website: https://nginx.org/
   repository: https://hg.nginx.org/nginx
 ---
+
+Nginx (pronounced "engine-x") is a high-performance HTTP server and reverse proxy, originally written by Igor Sysoev to solve the C10k problem of handling 10,000 concurrent connections. It has since become one of the most widely deployed web servers on the internet.
+
+Common use cases include serving static files, load balancing across application servers, SSL/TLS termination, and acting as an API gateway. Its event-driven, asynchronous architecture makes it highly efficient under heavy concurrent load.

--- a/exampleSite/content/en/catalog/catalog-007.md
+++ b/exampleSite/content/en/catalog/catalog-007.md
@@ -1,6 +1,14 @@
 ---
 title: Grafana
 description: An open and composable observability and data visualization platform.
+categories:
+  - observability
+tags:
+  - monitoring
+  - visualization
+prog_languages:
+  - Go
+  - TypeScript
 params:
   org_name: Grafana
   website: https://grafana.com/

--- a/exampleSite/content/en/catalog/catalog-007.md
+++ b/exampleSite/content/en/catalog/catalog-007.md
@@ -6,3 +6,7 @@ params:
   website: https://grafana.com/
   repository: https://github.com/grafana/grafana
 ---
+
+Grafana is an open source analytics and visualization platform that connects to a wide range of data sources — including Prometheus, Loki, Tempo, Elasticsearch, and many databases — to provide a unified observability view. Teams use it to build dashboards, set up alerting, and correlate metrics, logs, and traces in a single interface.
+
+Grafana's plugin system allows extending it with new data sources, panel types, and app plugins, making it adaptable to a broad range of monitoring and business intelligence use cases.

--- a/exampleSite/content/en/catalog/catalog-008.md
+++ b/exampleSite/content/en/catalog/catalog-008.md
@@ -1,6 +1,13 @@
 ---
 title: Prometheus
 description: An open source systems monitoring and alerting toolkit.
+categories:
+  - observability
+tags:
+  - monitoring
+  - metrics
+prog_languages:
+  - Go
 params:
   org_name: Prometheus
   website: https://prometheus.io/

--- a/exampleSite/content/en/catalog/catalog-008.md
+++ b/exampleSite/content/en/catalog/catalog-008.md
@@ -1,8 +1,12 @@
 ---
 title: Prometheus
-description: A progressive, incrementally-adoptable JavaScript framework for building UI on the web.
+description: An open source systems monitoring and alerting toolkit.
 params:
   org_name: Prometheus
   website: https://prometheus.io/
   repository: https://github.com/prometheus/prometheus
 ---
+
+Prometheus is an open source monitoring and alerting toolkit originally built at SoundCloud. It collects and stores time-series metrics as key/value pairs, using a powerful query language (PromQL) to slice, aggregate, and alert on those metrics in real time.
+
+Prometheus follows a pull model — it scrapes targets at configured intervals rather than waiting for agents to push data. This makes it straightforward to monitor microservices, Kubernetes workloads, and infrastructure components. It is a founding project of the Cloud Native Computing Foundation (CNCF).

--- a/exampleSite/content/en/catalog/catalog-009.md
+++ b/exampleSite/content/en/catalog/catalog-009.md
@@ -6,3 +6,7 @@ params:
   website: https://solr.apache.org/
   repository: https://github.com/apache/solr
 ---
+
+Apache Solr is a highly scalable, open source search platform built on Apache Lucene. It provides full-text search, faceted search, real-time indexing, dynamic clustering, database integration, and rich document handling, making it a popular choice for powering search on large content repositories and e-commerce sites.
+
+Solr exposes a REST-like API over HTTP and supports JSON, XML, and CSV for both indexing and querying. It can run standalone or in distributed mode (SolrCloud) for high availability and horizontal scalability.

--- a/exampleSite/content/en/docs/customization/shortcodes.md
+++ b/exampleSite/content/en/docs/customization/shortcodes.md
@@ -1,0 +1,40 @@
+---
+title: Shortcodes
+linkTitle: Shortcodes
+description: Custom shortcodes provided by the OSPO Hugo Theme
+weight: 10
+toc: true
+---
+
+Shortcodes are snippets you can drop into Markdown content to render theme-specific components that plain Markdown cannot express.
+
+## button
+
+Renders a styled call-to-action link.
+
+**Syntax**
+
+```text
+{{</* button link="<url>" text="<label>" */>}}
+```
+
+**Parameters**
+
+| Parameter | Required | Description |
+| --------- | :------: | ----------- |
+| `link`    | Yes      | Destination URL (relative or absolute). Relative URLs are expanded with Hugo's `absURL`. |
+| `text`    | Yes      | Visible button label. |
+
+**Examples**
+
+```text
+{{</* button link="catalog" text="Software Catalog" */>}}
+
+{{</* button link="https://github.com/ospo-ch/ospo-hugo-theme" text="View on GitHub" */>}}
+```
+
+**Output**
+
+{{< button link="catalog" text="Software Catalog" >}}
+
+{{< button link="https://github.com/ospo-ch/ospo-hugo-theme" text="View on GitHub" >}}

--- a/exampleSite/content/en/docs/customization/writing-content.md
+++ b/exampleSite/content/en/docs/customization/writing-content.md
@@ -175,6 +175,51 @@ func main() {
 }
 ```
 
+## Headings
+
+Hugo maps Markdown `#` headings to HTML `<h1>`–`<h6>`. Headings `h2`–`h4` appear in the table of contents when `toc: true` is set in frontmatter.
+
+```text
+## h2 heading
+### h3 heading
+#### h4 heading
+##### h5 heading
+```
+
+The render-heading hook adds anchor links automatically.
+
+## Horizontal rule
+
+```text
+---
+```
+
+---
+
+## Task lists
+
+```text
+- [x] Write the accessibility statement
+- [x] Add syntax highlighting examples
+- [ ] Publish the 1.0 release
+```
+
+- [x] Write the accessibility statement
+- [x] Add syntax highlighting examples
+- [ ] Publish the 1.0 release
+
+## Images
+
+```text
+![Alt text](https://via.placeholder.com/400x200 "Optional title")
+```
+
+To include a local image, place it under `static/images/` and reference it with a root-relative path:
+
+```text
+![Logo](/images/logo.svg)
+```
+
 ## Admonitions / Callouts
 
 **Input**

--- a/exampleSite/content/en/docs/customization/writing-content.md
+++ b/exampleSite/content/en/docs/customization/writing-content.md
@@ -131,36 +131,12 @@ Example `[example](https://example.com)` will display the link [example](https:/
 | Item #1   | Property #1 |     $1600 |
 | Item #2   | Property #2 |       $12 |
 | Item #3   | Property #3 |        $1 |
-| Item #1   | Property #1 |     $1600 |
-| Item #2   | Property #2 |       $12 |
-| Item #3   | Property #3 |        $1 |
-| Item #1   | Property #1 |     $1600 |
-| Item #2   | Property #2 |       $12 |
-| Item #3   | Property #3 |        $1 |
-| Item #1   | Property #1 |     $1600 |
-| Item #2   | Property #2 |       $12 |
-| Item #3   | Property #3 |        $1 |
-| Item #1   | Property #1 |     $1600 |
-| Item #2   | Property #2 |       $12 |
-| Item #3   | Property #3 |        $1 |
 ```
 
 **Output**
 
 | Column #1 |  Column #2  | Column #3 |
 | --------- | :---------: | --------: |
-| Item #1   | Property #1 |     $1600 |
-| Item #2   | Property #2 |       $12 |
-| Item #3   | Property #3 |        $1 |
-| Item #1   | Property #1 |     $1600 |
-| Item #2   | Property #2 |       $12 |
-| Item #3   | Property #3 |        $1 |
-| Item #1   | Property #1 |     $1600 |
-| Item #2   | Property #2 |       $12 |
-| Item #3   | Property #3 |        $1 |
-| Item #1   | Property #1 |     $1600 |
-| Item #2   | Property #2 |       $12 |
-| Item #3   | Property #3 |        $1 |
 | Item #1   | Property #1 |     $1600 |
 | Item #2   | Property #2 |       $12 |
 | Item #3   | Property #3 |        $1 |

--- a/exampleSite/content/en/docs/customization/writing-content.md
+++ b/exampleSite/content/en/docs/customization/writing-content.md
@@ -165,6 +165,40 @@ Example `[example](https://example.com)` will display the link [example](https:/
 | Item #2   | Property #2 |       $12 |
 | Item #3   | Property #3 |        $1 |
 
+## Code
+
+Use backtick-fenced blocks with a language identifier to get syntax highlighting. Inline code uses single backticks: `like this`.
+
+### YAML
+
+```yaml
+baseURL: https://example.com/
+title: My OSPO Portal
+
+params:
+  accessibility:
+    help_url: docs/accessibility/
+```
+
+### Bash
+
+```bash
+hugo mod get
+hugo server --environment development
+```
+
+### Go
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, OSPO!")
+}
+```
+
 ## Admonitions / Callouts
 
 **Input**

--- a/exampleSite/content/en/docs/getting-started/configuration.md
+++ b/exampleSite/content/en/docs/getting-started/configuration.md
@@ -1,0 +1,73 @@
+---
+title: Configuration
+linkTitle: Configuration
+description: Essential hugo.yaml settings for the OSPO Hugo Theme
+weight: 2
+toc: true
+---
+
+After installation, configure your site's `hugo.yaml` with the options below. A minimal working configuration is shown first, followed by explanations of each section.
+
+## Minimal configuration
+
+```yaml
+baseURL: https://example.com/
+languageCode: en
+title: My OSPO Portal
+
+params:
+  accessibility:
+    help_url: docs/accessibility/
+
+taxonomies:
+  categories: categories
+  tags: tags
+  prog_languages: prog_languages
+```
+
+## Params
+
+### Accessibility
+
+The `params.accessibility.help_url` value is used by the skip-navigation bar to link to your accessibility statement. Set it to the relative path of your accessibility page (e.g. `docs/accessibility/`). See the bundled [Accessibility Statement](/docs/accessibility/) for a template.
+
+## Multilingual support
+
+To enable English and French (or other languages), add a `languages` block:
+
+```yaml
+defaultContentLanguage: en
+defaultContentLanguageInSubdir: false
+
+languages:
+  en:
+    languageName: English
+    weight: 1
+  fr:
+    languageName: Français
+    weight: 2
+    params:
+      accessibility:
+        help_url: docs/accessibility/
+```
+
+Hugo does **not** fall back to another language's content for missing pages — each language must have its own content files.
+
+## Syntax highlighting
+
+The theme ships with a syntax highlighting stylesheet. To activate token-colored code blocks, set:
+
+```yaml
+markup:
+  highlight:
+    noClasses: false
+```
+
+## Custom styles
+
+Place your overrides in `assets/scss/` at your site root:
+
+- `_variables_project.scss` — override theme SCSS variables (colors, fonts, spacing)
+- `_styles_project.scss` — add custom rules or override theme styles
+
+These files are imported automatically; no changes to the theme are needed.

--- a/exampleSite/content/en/docs/getting-started/installation.md
+++ b/exampleSite/content/en/docs/getting-started/installation.md
@@ -1,0 +1,70 @@
+---
+title: Installation
+linkTitle: Installation
+description: How to add the OSPO Hugo Theme to your site
+weight: 1
+toc: true
+---
+
+The OSPO Hugo Theme can be added to an existing Hugo site in three ways. The Hugo Module approach is recommended because it keeps the theme version-pinned and updatable with a single command.
+
+## Prerequisites
+
+- [Hugo extended](https://gohugo.io/installation/) ≥ 0.134.0
+- [Go](https://go.dev/dl/) (required only for the Hugo Module method)
+
+## Method 1 — Hugo Module (recommended)
+
+1. Verify Go is installed:
+
+```bash
+go version
+```
+
+2. Initialize your site as a Hugo module (replace the path with your own):
+
+```bash
+hugo mod init github.com/<your_user>/<your-project>
+```
+
+3. Add the theme import to your `hugo.yaml` (or `hugo.toml`):
+
+```yaml
+module:
+  imports:
+    - path: github.com/ospo-ch/ospo-hugo-theme
+```
+
+4. Fetch the module:
+
+```bash
+hugo mod get
+```
+
+## Method 2 — Git submodule
+
+Inside your Hugo site directory:
+
+```bash
+git submodule add https://github.com/ospo-ch/ospo-hugo-theme.git themes/ospo
+```
+
+Then set the theme in your config:
+
+```yaml
+theme: ospo
+```
+
+To update to a newer version later:
+
+```bash
+git submodule update --remote --merge
+```
+
+## Method 3 — Clone
+
+```bash
+git clone https://github.com/ospo-ch/ospo-hugo-theme themes/ospo
+```
+
+Set `theme: ospo` in your config. To update, `cd themes/ospo && git pull`.

--- a/exampleSite/content/en/insights/_index.md
+++ b/exampleSite/content/en/insights/_index.md
@@ -1,3 +1,5 @@
 ---
-title: insights
+title: Insights
 ---
+
+Open source health reports for ospo.ch projects, scored across documentation, licensing, security, legal compliance, and best practices.

--- a/exampleSite/content/en/insights/ospo-theme.md
+++ b/exampleSite/content/en/insights/ospo-theme.md
@@ -1,6 +1,6 @@
 ---
-title: ospo theme
-description: A theme for the Hugo CMS to launch an ospo
+title: OSPO Hugo Theme
+description: A theme for the Hugo CMS to launch an OSPO
 params:
   org_name: ospo.ch
   repository: https://github.com/ospo-ch/ospo-hugo-theme
@@ -11,4 +11,179 @@ params:
     best_practices: 26
     security: 45
     legal: 100
+  repositories:
+    - name: ospo-hugo-theme
+      score:
+        documentation: 70
+        license: 75
+        best_practices: 26
+        security: 45
+        legal: 100
+        global: 63
+      documentation:
+        adopters:
+          id: adopters
+          title: Adopters
+          description: List of organizations using this project in production or at stages of testing
+          passed: false
+        changelog:
+          id: changelog
+          title: Changelog
+          description: A curated, chronologically ordered list of notable changes for each version
+          passed: true
+        code_of_conduct:
+          id: code_of_conduct
+          title: Code of conduct
+          description: Adopt a code of conduct to define community standards and outline procedures for handling abuse
+          passed: true
+        contributing:
+          id: contributing
+          title: Contributing
+          description: A contributing file provides potential contributors with a short guide to how they can help
+          passed: true
+        governance:
+          id: governance
+          title: Governance
+          description: Document that explains how the governance and committer process works in the repository
+          passed: false
+        maintainers:
+          id: maintainers
+          title: Maintainers
+          description: The maintainers file contains a list of the current maintainers for the repository
+          passed: false
+        readme:
+          id: readme
+          title: Readme
+          description: The readme file introduces and explains a project
+          passed: true
+        roadmap:
+          id: roadmap
+          title: Roadmap
+          description: Defines the high-level overview of the project's goals and deliverables
+          passed: false
+        website:
+          id: website
+          title: Website
+          description: A url that users can visit to learn more about your project
+          passed: true
+      license:
+        license_file_exists:
+          id: license_file_exists
+          title: License
+          description: The LICENSE file contains the repository license
+          passed: true
+          value: Apache-2.0
+        license_approved:
+          id: license_approved
+          title: Compliance
+          description: The license is approved within the organization
+          passed: true
+        license_scanning:
+          id: license_scanning
+          title: License scanning
+          description: Automatically identify, manage and address open source licensing issues
+          passed: false
+      best_practices:
+        cla:
+          id: cla
+          title: Contributor License Agreement
+          description: Defines the terms under which intellectual property has been contributed to a project
+          passed: false
+        dco:
+          id: dco
+          title: Developer Certificate of Origin
+          description: Mechanism for contributors to certify that they wrote or have the right to submit the code
+          passed: true
+        github_discussions:
+          id: github_discussions
+          title: GitHub Discussions
+          description: GitHub Discussions enable better collaboration on the project
+          passed: false
+        openssf_badge:
+          id: openssf_badge
+          title: OpenSSF Badge
+          description: The OpenSSF Best Practices badge shows that the project follows best practices
+          passed: false
+        openssf_scorecard_badge:
+          id: openssf_scorecard_badge
+          title: Scorecard Badge
+          description: Scorecard assesses open source projects for security risks through automated checks
+          passed: false
+        recent_release:
+          id: recent_release
+          title: Recent Release
+          description: The project should have released at least one version in the last year
+          passed: true
+        chat_presence:
+          id: chat_presence
+          title: Messaging support available
+          description: A messaging platform allows to build up the community for the project
+          passed: false
+        pull_request_template:
+          id: pull_request_template
+          title: Pull Request Template
+          description: A Pull Request template speeds up the approval process
+          passed: false
+        issue_template:
+          id: issue_template
+          title: Issue Template
+          description: An Issue template helps with filing bugs on the project
+          passed: false
+      security:
+        binary_artifacts:
+          id: binary_artifacts
+          title: Binary artifacts
+          description: This check determines whether the project has generated executable artifacts in the source repository
+          passed: true
+        code_review:
+          id: code_review
+          title: Code Review
+          description: This check determines whether the project requires code review before pull requests are merged
+          passed: true
+        dangerous_workflow:
+          id: dangerous_workflow
+          title: Dangerous Workflow
+          description: This check determines whether the project's GitHub Action workflows has dangerous code patterns
+          passed: true
+        dependency_policy:
+          id: dependency_policy
+          title: Dependency Policy
+          description: Project should provide a dependencies policy that describes how dependencies are consumed and updated
+          passed: false
+        dependency_update_tool:
+          id: dependency_update_tool
+          title: Dependency Update Tool
+          description: This check tries to determine if the project uses a dependency update tool
+          passed: true
+        maintained:
+          id: maintained
+          title: Maintained
+          description: This check determines whether the project is actively maintained
+          passed: true
+        security_policy:
+          id: security_policy
+          title: Security Policy
+          description: Clearly documented security processes explaining how to report security issues
+          passed: true
+        signed_releases:
+          id: signed_releases
+          title: Signed Release
+          description: This check tries to determine if the project cryptographically signs release artifacts
+          passed: false
+        sbom:
+          id: sbom
+          title: Software Bill of Materials
+          description: List of components in a piece of software, including licenses, versions, etc.
+          passed: false
+        token_permissions:
+          id: token_permissions
+          title: Token Permissions
+          description: This check determines whether the project's automated workflow tokens are set to read-only by default
+          passed: false
+      legal:
+        trademark_disclaimer:
+          id: trademark_disclaimer
+          title: Trademark
+          description: A trademark should be applied to protect intellectual property
+          passed: false
 ---

--- a/exampleSite/content/en/insights/ospo-utils.md
+++ b/exampleSite/content/en/insights/ospo-utils.md
@@ -1,5 +1,5 @@
 ---
-title: ospo utils
+title: OSPO Utils
 description: A set of scripts to build ospo.ch
 params:
   org_name: ospo.ch

--- a/exampleSite/content/en/insights/project-template.md
+++ b/exampleSite/content/en/insights/project-template.md
@@ -1,5 +1,5 @@
 ---
-title: ospo project template
+title: OSPO Project Template
 description: A repository template for ospo.ch projects
 params:
   org_name: ospo.ch

--- a/exampleSite/content/en/insights/project-template.md
+++ b/exampleSite/content/en/insights/project-template.md
@@ -179,7 +179,7 @@ params:
           id: token_permissions
           title: Token Permissions
           description: This check determines whether the project’s automated workflows tokens are set to read-only by default.
-          passed:
+          passed: false
       legal:
         trademark_disclaimer:
           id: trademark_disclaimer

--- a/exampleSite/content/en/projects/_index.md
+++ b/exampleSite/content/en/projects/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Projects
 ---
+
+Explore the active open source projects developed and maintained by ospo.ch, from Hugo themes to automation tooling and curated resource lists.

--- a/exampleSite/content/en/projects/awesome-codeswissgov.md
+++ b/exampleSite/content/en/projects/awesome-codeswissgov.md
@@ -1,7 +1,17 @@
 ---
-title: codeswissgov
-description: A curated list of OSS by Swiss Authorities
+title: Awesome CodeSwissGov
+description: A curated list of open source software by Swiss public authorities
 params:
   org_name: ospo.ch
   repository: https://github.com/ospo-ch/awesome-codeswissgov
 ---
+
+Awesome CodeSwissGov is a community-maintained list of open source projects published by Swiss federal and cantonal authorities. It follows the [awesome list](https://github.com/sindresorhus/awesome) format and is updated on a rolling basis as new repositories are identified.
+
+## Purpose
+
+Swiss public authorities are required under the Federal Act on the Use of Electronic Means for the Fulfilment of Government Tasks (EMBAG) to release software they develop as open source where possible. This list makes those releases discoverable in one place.
+
+## Contributing
+
+To add a project, open a pull request against the repository with a link, a short description, and the publishing authority. Projects must be publicly accessible and maintained by or for a Swiss public body.

--- a/exampleSite/content/en/projects/ospo-hugo-theme.md
+++ b/exampleSite/content/en/projects/ospo-hugo-theme.md
@@ -1,7 +1,21 @@
 ---
-title: ospo theme
-description: A theme for the Hugo CMS to launch an ospo
+title: OSPO Hugo Theme
+description: A theme for the Hugo CMS to launch an OSPO
 params:
   org_name: ospo.ch
   repository: https://github.com/ospo-ch/ospo-hugo-theme
 ---
+
+The OSPO Hugo Theme provides a ready-made website for organizations running an Open Source Program Office. Built on [Hugo](https://gohugo.io), it ships with a software catalog, project pages, health-score insights, and multilingual support out of the box.
+
+## Features
+
+- **Software Catalog** — list and describe the open source tools your organization uses or maintains
+- **Projects** — showcase active open source projects with repository links and status
+- **Insights** — publish automated health scores across documentation, licensing, security, and best-practices dimensions
+- **Multilingual** — English and French supported; add further languages via Hugo's i18n system
+- **Docs section** — write guides and policies using standard Markdown with callouts, tables, and syntax highlighting
+
+## Status
+
+Actively developed and used for [ospo.ch](https://ospo.ch). Contributions welcome via the repository.

--- a/exampleSite/content/fr/_index.md
+++ b/exampleSite/content/fr/_index.md
@@ -5,8 +5,8 @@ description: Ceci est un exemple de site pour le thème ospo. Ce thème a été 
 
 Ceci est un exemple de site pour le thème ospo. Ce thème a été créé pour le CMS Hugo, et a été développé et publié par ospo.ch.
 
-{{< button link="catalog" text="Software Catalog" >}}
+{{< button link="catalog" text="Catalogue" >}}
 
-{{< button link="projects" text="Projects" >}}
+{{< button link="projects" text="Projets" >}}
 
-{{< button link="insights" text="Insights" >}}
+{{< button link="insights" text="Évaluation" >}}

--- a/exampleSite/content/fr/_index.md
+++ b/exampleSite/content/fr/_index.md
@@ -1,9 +1,9 @@
 ---
-title: ospo theme demo
+title: OSPO Theme Demo
 description: Ceci est un exemple de site pour le thème ospo. Ce thème a été créé pour le CMS Hugo, et a été développé et publié par ospo.ch.
 ---
 
-Ceci est un exemple de site pour le thème ospo. Ce thème a été créé pour le CMS Hugo, et a été développé et publié par ospo.ch.
+Explorez notre catalogue logiciel, nos projets actifs et nos rapports de santé open source. Construit avec l'[OSPO Hugo Theme](https://github.com/ospo-ch/ospo-hugo-theme) — un portail clé en main pour les Open Source Program Offices.
 
 {{< button link="catalog" text="Catalogue" >}}
 

--- a/exampleSite/content/fr/catalog/_index.md
+++ b/exampleSite/content/fr/catalog/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Catalogue des logiciels
 ---
+
+Parcourez les logiciels open source maintenus et utilisés par ospo.ch. Chaque entrée comprend une description, des informations de licence et des liens vers le dépôt source.

--- a/exampleSite/content/fr/catalog/catalog-001.md
+++ b/exampleSite/content/fr/catalog/catalog-001.md
@@ -6,3 +6,7 @@ params:
   website: https://react.dev/
   repository: https://github.com/facebook/react
 ---
+
+React est une bibliothèque JavaScript déclarative et orientée composants pour la création d'interfaces utilisateur, maintenue par Meta et une large communauté open source. Elle a introduit le DOM virtuel afin de minimiser les mises à jour coûteuses du DOM réel, et a popularisé la composition d'interfaces à partir de petits composants réutilisables.
+
+Le flux de données unidirectionnel de React et son API de hooks facilitent la gestion de l'état et des effets secondaires au sein des composants. Elle est largement utilisée pour les applications monopage et peut être rendue côté serveur via des frameworks tels que Next.js.

--- a/exampleSite/content/fr/catalog/catalog-001.md
+++ b/exampleSite/content/fr/catalog/catalog-001.md
@@ -1,6 +1,13 @@
 ---
 title: React
 description: Une bibliothèque JavaScript pour créer des interfaces utilisateur.
+categories:
+  - frontend
+tags:
+  - javascript
+  - ui-library
+prog_languages:
+  - JavaScript
 params:
   org_name: Meta
   website: https://react.dev/

--- a/exampleSite/content/fr/catalog/catalog-002.md
+++ b/exampleSite/content/fr/catalog/catalog-002.md
@@ -1,6 +1,13 @@
 ---
 title: Vue.js
 description: Un framework JavaScript progressif et adoptable de manière incrémentale pour créer une interface utilisateur sur le Web.
+categories:
+  - frontend
+tags:
+  - javascript
+  - framework
+prog_languages:
+  - JavaScript
 params:
   org_name: Vue
   website: https://vuejs.org/

--- a/exampleSite/content/fr/catalog/catalog-002.md
+++ b/exampleSite/content/fr/catalog/catalog-002.md
@@ -6,3 +6,7 @@ params:
   website: https://vuejs.org/
   repository: https://github.com/vuejs/core
 ---
+
+Vue.js est un framework JavaScript progressif pour la création d'interfaces utilisateur. Contrairement aux frameworks monolithiques, Vue est conçu pour être adopté de manière incrémentale — sa bibliothèque principale se concentre uniquement sur la couche vue, ce qui facilite son intégration dans des projets existants ou son utilisation comme base pour une application monopage complète.
+
+Le système de réactivité de Vue suit automatiquement les dépendances au niveau des composants, et son format de composant mono-fichier (SFC) regroupe le template, le script et le style dans un seul fichier `.vue` pour une meilleure maintenabilité.

--- a/exampleSite/content/fr/catalog/catalog-003.md
+++ b/exampleSite/content/fr/catalog/catalog-003.md
@@ -6,7 +6,7 @@ categories:
 tags:
   - automation
   - deployment
-languages:
+prog_languages:
   - Python
 
 params:

--- a/exampleSite/content/fr/catalog/catalog-003.md
+++ b/exampleSite/content/fr/catalog/catalog-003.md
@@ -15,6 +15,6 @@ params:
   repository: https://github.com/ansible/ansible
 ---
 
-Ansible is a suite of software tools that enables infrastructure as code. It is open-source and the suite includes software provisioning, configuration management, and application deployment functionality.
+Ansible est une suite d'outils logiciels permettant l'infrastructure en tant que code. Elle est open source et comprend des fonctionnalités de provisionnement de logiciels, de gestion de la configuration et de déploiement d'applications.
 
-Originally written by Michael DeHaan in 2012, and acquired by Red Hat in 2015, Ansible is designed to configure both Unix-like systems and Microsoft Windows. Ansible is agentless, relying on temporary remote connections via SSH or Windows Remote Management which allows PowerShell execution. The Ansible control node runs on most Unix-like systems that are able to run Python, including Windows with Windows Subsystem for Linux installed. System configuration is defined in part by using its own declarative language.
+Écrite à l'origine par Michael DeHaan en 2012 et acquise par Red Hat en 2015, Ansible est conçue pour configurer aussi bien les systèmes de type Unix que Microsoft Windows. Ansible est sans agent : elle s'appuie sur des connexions distantes temporaires via SSH ou Windows Remote Management avec PowerShell. Sa configuration est définie à l'aide d'un langage déclaratif propre à la plateforme.

--- a/exampleSite/content/fr/catalog/catalog-004.md
+++ b/exampleSite/content/fr/catalog/catalog-004.md
@@ -1,6 +1,13 @@
 ---
 title: Docker
 description: Un projet collaboratif pour l'écosystème des conteneurs afin d'assembler des systèmes basés sur des conteneurs.
+categories:
+  - devops
+tags:
+  - containers
+  - deployment
+prog_languages:
+  - Go
 params:
   org_name: Moby
   website: https://www.docker.com/

--- a/exampleSite/content/fr/catalog/catalog-004.md
+++ b/exampleSite/content/fr/catalog/catalog-004.md
@@ -6,3 +6,7 @@ params:
   website: https://www.docker.com/
   repository: https://github.com/moby/moby
 ---
+
+Docker est une plateforme open source permettant de développer, expédier et exécuter des applications dans des conteneurs légers et portables. Les conteneurs regroupent une application avec toutes ses dépendances dans une unité standardisée, éliminant les incohérences entre les environnements de développement, de staging et de production.
+
+Le projet Moby est le composant open source en amont sur lequel Docker Engine est construit. Il fournit le démon, le client CLI, le runtime de conteneurs, le constructeur d'images et les sous-systèmes réseau utilisés par Docker Desktop et d'autres plateformes de conteneurs.

--- a/exampleSite/content/fr/catalog/catalog-005.md
+++ b/exampleSite/content/fr/catalog/catalog-005.md
@@ -1,6 +1,13 @@
 ---
 title: PostgreSQL
 description: Un système de base de données relationnelle objet puissant et open source.
+categories:
+  - database
+tags:
+  - sql
+  - storage
+prog_languages:
+  - C
 params:
   org_name: PostgreSQL
   website: https://www.postgresql.org/

--- a/exampleSite/content/fr/catalog/catalog-005.md
+++ b/exampleSite/content/fr/catalog/catalog-005.md
@@ -6,3 +6,7 @@ params:
   website: https://www.postgresql.org/
   repository: https://git.postgresql.org/gitweb/?p=postgresql.git
 ---
+
+PostgreSQL est un système de base de données relationnelle objet conforme aux normes, développé activement depuis plus de 35 ans. Il offre une conformité ACID complète, des requêtes complexes, les clés étrangères, les déclencheurs, les vues modifiables, l'intégrité transactionnelle et le contrôle de la concurrence par multiversionnement (MVCC).
+
+PostgreSQL fonctionne sur tous les grands systèmes d'exploitation et prend en charge une large gamme de types de données, de méthodes d'indexation et de langages procéduraux. Son modèle d'extensibilité permet aux utilisateurs de définir des fonctions, opérateurs, types d'index et même de nouveaux types de données personnalisés.

--- a/exampleSite/content/fr/catalog/catalog-006.md
+++ b/exampleSite/content/fr/catalog/catalog-006.md
@@ -6,3 +6,7 @@ params:
   website: https://nginx.org/
   repository: https://hg.nginx.org/nginx
 ---
+
+Nginx (prononcé « engine-x ») est un serveur HTTP haute performance et proxy inverse, écrit à l'origine par Igor Sysoev pour résoudre le problème C10k — gérer 10 000 connexions simultanées. Il est aujourd'hui l'un des serveurs web les plus déployés sur Internet.
+
+Ses cas d'utilisation courants incluent la diffusion de fichiers statiques, la répartition de charge entre serveurs applicatifs, la terminaison SSL/TLS et la fonction de passerelle API. Son architecture événementielle et asynchrone le rend particulièrement efficace sous forte charge simultanée.

--- a/exampleSite/content/fr/catalog/catalog-007.md
+++ b/exampleSite/content/fr/catalog/catalog-007.md
@@ -1,6 +1,14 @@
 ---
 title: Grafana
 description: Une plateforme d'observabilité et de visualisation de données ouverte et composable.
+categories:
+  - observability
+tags:
+  - monitoring
+  - visualization
+prog_languages:
+  - Go
+  - TypeScript
 params:
   org_name: Grafana
   website: https://grafana.com/

--- a/exampleSite/content/fr/catalog/catalog-007.md
+++ b/exampleSite/content/fr/catalog/catalog-007.md
@@ -1,8 +1,12 @@
 ---
 title: Grafana
-description: Une plateforme d'observabilité et de visualisation de données.
+description: Une plateforme d'observabilité et de visualisation de données ouverte et composable.
 params:
   org_name: Grafana
   website: https://grafana.com/
   repository: https://github.com/grafana/grafana
 ---
+
+Grafana est une plateforme open source d'analyse et de visualisation qui se connecte à de nombreuses sources de données — dont Prometheus, Loki, Tempo, Elasticsearch et plusieurs bases de données — pour offrir une vue d'observabilité unifiée. Les équipes l'utilisent pour créer des tableaux de bord, configurer des alertes et corréler métriques, journaux et traces dans une seule interface.
+
+Le système de plugins de Grafana permet de l'étendre avec de nouvelles sources de données, de nouveaux types de panneaux et des plugins d'application, le rendant adaptable à une large gamme de cas d'usage en monitoring et en business intelligence.

--- a/exampleSite/content/fr/catalog/catalog-008.md
+++ b/exampleSite/content/fr/catalog/catalog-008.md
@@ -1,6 +1,13 @@
 ---
 title: Prometheus
 description: Un système de surveillance et d'alerte open source.
+categories:
+  - observability
+tags:
+  - monitoring
+  - metrics
+prog_languages:
+  - Go
 params:
   org_name: Prometheus
   website: https://prometheus.io/

--- a/exampleSite/content/fr/catalog/catalog-008.md
+++ b/exampleSite/content/fr/catalog/catalog-008.md
@@ -1,8 +1,12 @@
 ---
 title: Prometheus
-description: Un framework JavaScript progressif et adoptable de manière incrémentale pour créer une interface utilisateur sur le Web.
+description: Un système de surveillance et d'alerte open source.
 params:
   org_name: Prometheus
   website: https://prometheus.io/
   repository: https://github.com/prometheus/prometheus
 ---
+
+Prometheus est un outil open source de surveillance et d'alerte initialement développé chez SoundCloud. Il collecte et stocke des métriques en séries temporelles sous forme de paires clé/valeur, en utilisant un puissant langage de requête (PromQL) pour les découper, les agréger et déclencher des alertes en temps réel.
+
+Prometheus suit un modèle pull — il interroge les cibles à intervalles configurés plutôt que d'attendre que des agents envoient des données. Cela facilite la surveillance des microservices, des charges de travail Kubernetes et des composants d'infrastructure. C'est un projet fondateur de la Cloud Native Computing Foundation (CNCF).

--- a/exampleSite/content/fr/catalog/catalog-009.md
+++ b/exampleSite/content/fr/catalog/catalog-009.md
@@ -6,3 +6,7 @@ params:
   website: https://solr.apache.org/
   repository: https://github.com/apache/solr
 ---
+
+Apache Solr est une plateforme de recherche open source hautement évolutive, construite sur Apache Lucene. Elle offre la recherche en texte intégral, la recherche à facettes, l'indexation en temps réel, le clustering dynamique, l'intégration de bases de données et la gestion de documents enrichis, ce qui en fait un choix populaire pour les moteurs de recherche sur de grands dépôts de contenu et les sites de commerce électronique.
+
+Solr expose une API REST via HTTP et prend en charge JSON, XML et CSV pour l'indexation comme pour les requêtes. Il peut fonctionner en mode autonome ou en mode distribué (SolrCloud) pour la haute disponibilité et la scalabilité horizontale.

--- a/exampleSite/content/fr/docs/accessibility/_index.md
+++ b/exampleSite/content/fr/docs/accessibility/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Déclaration d'accessibilité"
+linkTitle: "Déclaration d'accessibilité"
+description: >
+  ospo.ch s'engage à garantir l'accessibilité numérique aux personnes en situation de handicap. Nous améliorons continuellement l'expérience utilisateur pour toutes et tous, en appliquant les normes d'accessibilité pertinentes.
+weight: 15
+toc: true
+---
+
+## Statut de conformité
+
+Les [Règles pour l'accessibilité des contenus Web (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/) définissent les exigences que les concepteurs et développeurs doivent respecter pour améliorer l'accessibilité aux personnes en situation de handicap. Elles définissent trois niveaux de conformité : niveau A, niveau AA et niveau AAA. OSPO Hugo Theme est partiellement conforme au niveau AA des WCAG 2.1. Une conformité partielle signifie que certaines parties du contenu ne sont pas entièrement conformes à la norme d'accessibilité.
+
+## Spécifications techniques
+
+L'accessibilité de OSPO Hugo Theme repose sur les technologies suivantes pour fonctionner avec la combinaison particulière de navigateur web et d'éventuelles technologies d'assistance ou extensions installées sur votre ordinateur :
+
+- HTML
+- WAI-ARIA
+- CSS
+- JavaScript
+
+Ces technologies sont indispensables pour la conformité aux normes d'accessibilité utilisées.
+
+## Approche d'évaluation
+
+ospo.ch a évalué l'accessibilité de OSPO Hugo Theme selon les approches suivantes :
+
+- Auto-évaluation
+
+## Date
+
+Cette déclaration a été créée le 9 avril 2025 à l'aide de l'[outil de génération de déclarations d'accessibilité du W3C](https://www.w3.org/WAI/planning/statements/).

--- a/exampleSite/content/fr/docs/customization/shortcodes.md
+++ b/exampleSite/content/fr/docs/customization/shortcodes.md
@@ -1,0 +1,40 @@
+---
+title: Shortcodes
+linkTitle: Shortcodes
+description: Shortcodes personnalisés fournis par le thème OSPO Hugo
+weight: 10
+toc: true
+---
+
+Les shortcodes sont des extraits que vous pouvez insérer dans le contenu Markdown pour afficher des composants spécifiques au thème que le Markdown standard ne permet pas d'exprimer.
+
+## button
+
+Affiche un lien d'appel à l'action stylisé.
+
+**Syntaxe**
+
+```text
+{{</* button link="<url>" text="<libellé>" */>}}
+```
+
+**Paramètres**
+
+| Paramètre | Requis | Description |
+| --------- | :----: | ----------- |
+| `link`    | Oui    | URL de destination (relative ou absolue). Les URL relatives sont développées avec `absURL` de Hugo. |
+| `text`    | Oui    | Libellé visible du bouton. |
+
+**Exemples**
+
+```text
+{{</* button link="catalog" text="Catalogue" */>}}
+
+{{</* button link="https://github.com/ospo-ch/ospo-hugo-theme" text="Voir sur GitHub" */>}}
+```
+
+**Résultat**
+
+{{< button link="catalog" text="Catalogue" >}}
+
+{{< button link="https://github.com/ospo-ch/ospo-hugo-theme" text="Voir sur GitHub" >}}

--- a/exampleSite/content/fr/docs/customization/writing-content.md
+++ b/exampleSite/content/fr/docs/customization/writing-content.md
@@ -175,6 +175,51 @@ func main() {
 }
 ```
 
+## En-têtes
+
+Hugo convertit les en-têtes Markdown `#` en balises HTML `<h1>`–`<h6>`. Les niveaux `h2`–`h4` apparaissent dans la table des matières lorsque `toc: true` est défini dans le frontmatter.
+
+```text
+## En-tête h2
+### En-tête h3
+#### En-tête h4
+##### En-tête h5
+```
+
+Le hook render-heading ajoute automatiquement des liens d'ancrage.
+
+## Règle horizontale
+
+```text
+---
+```
+
+---
+
+## Listes de tâches
+
+```text
+- [x] Rédiger la déclaration d'accessibilité
+- [x] Ajouter des exemples de coloration syntaxique
+- [ ] Publier la version 1.0
+```
+
+- [x] Rédiger la déclaration d'accessibilité
+- [x] Ajouter des exemples de coloration syntaxique
+- [ ] Publier la version 1.0
+
+## Images
+
+```text
+![Texte alternatif](https://via.placeholder.com/400x200 "Titre optionnel")
+```
+
+Pour inclure une image locale, placez-la dans `static/images/` et référencez-la avec un chemin relatif à la racine :
+
+```text
+![Logo](/images/logo.svg)
+```
+
 ## Admonitions / Blocs d'alerte
 
 **Entrée**

--- a/exampleSite/content/fr/docs/customization/writing-content.md
+++ b/exampleSite/content/fr/docs/customization/writing-content.md
@@ -137,9 +137,9 @@ Exemple : `[exemple](https://example.com)` affichera le lien [exemple](https://e
 
 | Colonne n°1 | Colonne n°2 | Colonne n°3 |
 | ----------- | :---------: | ----------: |
-| Élément n°1 | Propriété 1 |      1 600 € |
-| Élément n°2 | Propriété 2 |         12 € |
-| Élément n°3 | Propriété 3 |          1 € |
+| Élément n°1 | Propriété 1 |       1 600 € |
+| Élément n°2 | Propriété 2 |          12 € |
+| Élément n°3 | Propriété 3 |           1 € |
 
 ## Code
 

--- a/exampleSite/content/fr/docs/customization/writing-content.md
+++ b/exampleSite/content/fr/docs/customization/writing-content.md
@@ -141,6 +141,40 @@ Exemple : `[exemple](https://example.com)` affichera le lien [exemple](https://e
 | Élément n°2 | Propriété 2 |         12 € |
 | Élément n°3 | Propriété 3 |          1 € |
 
+## Code
+
+Utilisez des blocs délimités par des backticks avec un identifiant de langage pour obtenir la coloration syntaxique. Le code en ligne utilise des backticks simples : `comme ceci`.
+
+### YAML
+
+```yaml
+baseURL: https://example.com/
+title: Mon portail OSPO
+
+params:
+  accessibility:
+    help_url: docs/accessibility/
+```
+
+### Bash
+
+```bash
+hugo mod get
+hugo server --environment development
+```
+
+### Go
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Bonjour, OSPO !")
+}
+```
+
 ## Admonitions / Blocs d'alerte
 
 **Entrée**

--- a/exampleSite/content/fr/docs/customization/writing-content.md
+++ b/exampleSite/content/fr/docs/customization/writing-content.md
@@ -1,0 +1,180 @@
+---
+title: Rédiger du contenu
+linkTitle: Rédiger du contenu
+description: >
+  Comment rédiger du contenu
+weight: 5
+toc: true
+---
+
+## Titres
+
+Utilisés de préférence pour les en-têtes de section.
+
+```text
+## Titres
+```
+
+### Sous-titres
+
+```text
+### Sous-titres
+```
+
+## Mise en forme du texte
+
+Gras : utilisez `**` autour du texte. `**gras**` s'affichera comme **gras**.
+
+Italique : utilisez `_` autour du texte. `_italique_` s'affichera comme _italique_.
+
+Texte barré : utilisez `~` autour du texte. `~barré~` s'affichera comme ~barré~.
+
+## Liens
+
+Exemple : `[exemple](https://example.com)` affichera le lien [exemple](https://example.com).
+
+## Citations
+
+### Ligne unique
+
+**Entrée**
+
+```text
+> Ceci est une citation sur une seule ligne
+```
+
+**Résultat**
+
+> Ceci est une citation sur une seule ligne
+
+### Multiligne
+
+**Entrée**
+
+```text
+> Ce texte s'affichera sur plusieurs lignes.
+>
+> Fin.
+```
+
+**Résultat**
+
+> Ce texte s'affichera sur plusieurs lignes.
+>
+> Fin.
+
+## Listes
+
+### Liste ordonnée
+
+**Entrée**
+
+```text
+1. Premier élément
+2. Deuxième élément
+3. Troisième élément
+4. Quatrième élément
+```
+
+**Résultat**
+
+1. Premier élément
+2. Deuxième élément
+3. Troisième élément
+4. Quatrième élément
+
+### Liste non ordonnée
+
+**Entrée**
+
+```text
+- Premier élément
+- Deuxième élément
+- Troisième élément
+- Quatrième élément
+```
+
+**Résultat**
+
+- Premier élément
+- Deuxième élément
+- Troisième élément
+- Quatrième élément
+
+### Liste imbriquée
+
+**Entrée**
+
+```text
+- Premier élément
+- Deuxième élément
+  - Élément supplémentaire
+  - Élément supplémentaire
+- Troisième élément
+```
+
+**Résultat**
+
+- Premier élément
+- Deuxième élément
+  - Élément supplémentaire
+  - Élément supplémentaire
+- Troisième élément
+
+### Tableaux
+
+**Entrée**
+
+```text
+| Colonne n°1 | Colonne n°2 | Colonne n°3 |
+| ----------- | :---------: | ----------: |
+| Élément n°1 | Propriété 1 |      1 600 € |
+| Élément n°2 | Propriété 2 |         12 € |
+| Élément n°3 | Propriété 3 |          1 € |
+```
+
+**Résultat**
+
+| Colonne n°1 | Colonne n°2 | Colonne n°3 |
+| ----------- | :---------: | ----------: |
+| Élément n°1 | Propriété 1 |      1 600 € |
+| Élément n°2 | Propriété 2 |         12 € |
+| Élément n°3 | Propriété 3 |          1 € |
+
+## Admonitions / Blocs d'alerte
+
+**Entrée**
+
+```text
+> [!NOTE]
+> Informations utiles que les utilisateurs doivent connaître, même en parcourant rapidement le contenu.
+
+> [!TIP]
+> Conseils pour mieux faire les choses ou plus facilement.
+
+> [!IMPORTANT]
+> Informations clés que les utilisateurs doivent connaître pour atteindre leur objectif.
+
+> [!WARNING]
+> Informations urgentes nécessitant une attention immédiate pour éviter des problèmes.
+
+> [!CAUTION]
+> Avertissements sur les risques ou les conséquences négatives de certaines actions.
+```
+
+**Résultat**
+
+> [!NOTE]
+> Informations utiles que les utilisateurs doivent connaître, même en parcourant rapidement le contenu.
+
+> [!TIP]
+> Conseils pour mieux faire les choses ou plus facilement.
+
+> [!IMPORTANT]
+> Informations clés que les utilisateurs doivent connaître pour atteindre leur objectif.
+
+> [!WARNING]
+> Informations urgentes nécessitant une attention immédiate pour éviter des problèmes.
+
+> [!CAUTION]
+> Avertissements sur les risques ou les conséquences négatives de certaines actions.

--- a/exampleSite/content/fr/docs/getting-started/configuration.md
+++ b/exampleSite/content/fr/docs/getting-started/configuration.md
@@ -1,0 +1,73 @@
+---
+title: Configuration
+linkTitle: Configuration
+description: Paramètres essentiels de hugo.yaml pour le thème OSPO Hugo
+weight: 2
+toc: true
+---
+
+Après l'installation, configurez le fichier `hugo.yaml` de votre site avec les options ci-dessous. Une configuration minimale fonctionnelle est présentée en premier, suivie des explications de chaque section.
+
+## Configuration minimale
+
+```yaml
+baseURL: https://example.com/
+languageCode: fr
+title: Mon portail OSPO
+
+params:
+  accessibility:
+    help_url: docs/accessibility/
+
+taxonomies:
+  categories: categories
+  tags: tags
+  prog_languages: prog_languages
+```
+
+## Paramètres
+
+### Accessibilité
+
+La valeur `params.accessibility.help_url` est utilisée par la barre de navigation rapide pour créer un lien vers votre déclaration d'accessibilité. Définissez-la sur le chemin relatif de votre page d'accessibilité (ex. : `docs/accessibility/`). Consultez la [Déclaration d'accessibilité](/fr/docs/accessibility/) fournie comme modèle.
+
+## Support multilingue
+
+Pour activer l'anglais et le français (ou d'autres langues), ajoutez un bloc `languages` :
+
+```yaml
+defaultContentLanguage: en
+defaultContentLanguageInSubdir: false
+
+languages:
+  en:
+    languageName: English
+    weight: 1
+  fr:
+    languageName: Français
+    weight: 2
+    params:
+      accessibility:
+        help_url: docs/accessibility/
+```
+
+Hugo ne substitue **pas** le contenu d'une autre langue pour les pages manquantes — chaque langue doit disposer de ses propres fichiers de contenu.
+
+## Coloration syntaxique
+
+Le thème est livré avec une feuille de style pour la coloration syntaxique. Pour activer les blocs de code avec couleurs, définissez :
+
+```yaml
+markup:
+  highlight:
+    noClasses: false
+```
+
+## Styles personnalisés
+
+Placez vos surcharges dans `assets/scss/` à la racine de votre site :
+
+- `_variables_project.scss` — redéfinissez les variables SCSS du thème (couleurs, polices, espacements)
+- `_styles_project.scss` — ajoutez des règles personnalisées ou surchargez les styles du thème
+
+Ces fichiers sont importés automatiquement ; aucune modification du thème n'est nécessaire.

--- a/exampleSite/content/fr/docs/getting-started/installation.md
+++ b/exampleSite/content/fr/docs/getting-started/installation.md
@@ -1,0 +1,70 @@
+---
+title: Installation
+linkTitle: Installation
+description: Comment ajouter le thème OSPO Hugo à votre site
+weight: 1
+toc: true
+---
+
+Le thème OSPO Hugo peut être ajouté à un site Hugo existant de trois manières. L'approche par module Hugo est recommandée car elle verrouille la version du thème et permet sa mise à jour en une seule commande.
+
+## Prérequis
+
+- [Hugo extended](https://gohugo.io/installation/) ≥ 0.134.0
+- [Go](https://go.dev/dl/) (requis uniquement pour la méthode Module Hugo)
+
+## Méthode 1 — Module Hugo (recommandé)
+
+1. Vérifiez que Go est installé :
+
+```bash
+go version
+```
+
+2. Initialisez votre site en tant que module Hugo (remplacez le chemin par le vôtre) :
+
+```bash
+hugo mod init github.com/<votre_utilisateur>/<votre-projet>
+```
+
+3. Ajoutez l'import du thème dans votre `hugo.yaml` (ou `hugo.toml`) :
+
+```yaml
+module:
+  imports:
+    - path: github.com/ospo-ch/ospo-hugo-theme
+```
+
+4. Récupérez le module :
+
+```bash
+hugo mod get
+```
+
+## Méthode 2 — Sous-module Git
+
+Dans le répertoire de votre site Hugo :
+
+```bash
+git submodule add https://github.com/ospo-ch/ospo-hugo-theme.git themes/ospo
+```
+
+Puis définissez le thème dans votre configuration :
+
+```yaml
+theme: ospo
+```
+
+Pour mettre à jour vers une version plus récente :
+
+```bash
+git submodule update --remote --merge
+```
+
+## Méthode 3 — Clonage
+
+```bash
+git clone https://github.com/ospo-ch/ospo-hugo-theme themes/ospo
+```
+
+Définissez `theme: ospo` dans votre configuration. Pour mettre à jour, exécutez `cd themes/ospo && git pull`.

--- a/exampleSite/content/fr/insights/_index.md
+++ b/exampleSite/content/fr/insights/_index.md
@@ -1,3 +1,5 @@
 ---
-title: insights
+title: Évaluation
 ---
+
+Rapports de santé open source pour les projets ospo.ch, évalués selon la documentation, les licences, la sécurité, la conformité juridique et les bonnes pratiques.

--- a/exampleSite/content/fr/insights/ospo-theme.md
+++ b/exampleSite/content/fr/insights/ospo-theme.md
@@ -1,6 +1,6 @@
 ---
-title: ospo theme
-description: A theme for the Hugo CMS to launch an ospo
+title: OSPO Hugo Theme
+description: A theme for the Hugo CMS to launch an OSPO
 params:
   org_name: ospo.ch
   repository: https://github.com/ospo-ch/ospo-hugo-theme
@@ -11,4 +11,179 @@ params:
     best_practices: 26
     security: 45
     legal: 100
+  repositories:
+    - name: ospo-hugo-theme
+      score:
+        documentation: 70
+        license: 75
+        best_practices: 26
+        security: 45
+        legal: 100
+        global: 63
+      documentation:
+        adopters:
+          id: adopters
+          title: Adopters
+          description: List of organizations using this project in production or at stages of testing
+          passed: false
+        changelog:
+          id: changelog
+          title: Changelog
+          description: A curated, chronologically ordered list of notable changes for each version
+          passed: true
+        code_of_conduct:
+          id: code_of_conduct
+          title: Code of conduct
+          description: Adopt a code of conduct to define community standards and outline procedures for handling abuse
+          passed: true
+        contributing:
+          id: contributing
+          title: Contributing
+          description: A contributing file provides potential contributors with a short guide to how they can help
+          passed: true
+        governance:
+          id: governance
+          title: Governance
+          description: Document that explains how the governance and committer process works in the repository
+          passed: false
+        maintainers:
+          id: maintainers
+          title: Maintainers
+          description: The maintainers file contains a list of the current maintainers for the repository
+          passed: false
+        readme:
+          id: readme
+          title: Readme
+          description: The readme file introduces and explains a project
+          passed: true
+        roadmap:
+          id: roadmap
+          title: Roadmap
+          description: Defines the high-level overview of the project's goals and deliverables
+          passed: false
+        website:
+          id: website
+          title: Website
+          description: A url that users can visit to learn more about your project
+          passed: true
+      license:
+        license_file_exists:
+          id: license_file_exists
+          title: License
+          description: The LICENSE file contains the repository license
+          passed: true
+          value: Apache-2.0
+        license_approved:
+          id: license_approved
+          title: Compliance
+          description: The license is approved within the organization
+          passed: true
+        license_scanning:
+          id: license_scanning
+          title: License scanning
+          description: Automatically identify, manage and address open source licensing issues
+          passed: false
+      best_practices:
+        cla:
+          id: cla
+          title: Contributor License Agreement
+          description: Defines the terms under which intellectual property has been contributed to a project
+          passed: false
+        dco:
+          id: dco
+          title: Developer Certificate of Origin
+          description: Mechanism for contributors to certify that they wrote or have the right to submit the code
+          passed: true
+        github_discussions:
+          id: github_discussions
+          title: GitHub Discussions
+          description: GitHub Discussions enable better collaboration on the project
+          passed: false
+        openssf_badge:
+          id: openssf_badge
+          title: OpenSSF Badge
+          description: The OpenSSF Best Practices badge shows that the project follows best practices
+          passed: false
+        openssf_scorecard_badge:
+          id: openssf_scorecard_badge
+          title: Scorecard Badge
+          description: Scorecard assesses open source projects for security risks through automated checks
+          passed: false
+        recent_release:
+          id: recent_release
+          title: Recent Release
+          description: The project should have released at least one version in the last year
+          passed: true
+        chat_presence:
+          id: chat_presence
+          title: Messaging support available
+          description: A messaging platform allows to build up the community for the project
+          passed: false
+        pull_request_template:
+          id: pull_request_template
+          title: Pull Request Template
+          description: A Pull Request template speeds up the approval process
+          passed: false
+        issue_template:
+          id: issue_template
+          title: Issue Template
+          description: An Issue template helps with filing bugs on the project
+          passed: false
+      security:
+        binary_artifacts:
+          id: binary_artifacts
+          title: Binary artifacts
+          description: This check determines whether the project has generated executable artifacts in the source repository
+          passed: true
+        code_review:
+          id: code_review
+          title: Code Review
+          description: This check determines whether the project requires code review before pull requests are merged
+          passed: true
+        dangerous_workflow:
+          id: dangerous_workflow
+          title: Dangerous Workflow
+          description: This check determines whether the project's GitHub Action workflows has dangerous code patterns
+          passed: true
+        dependency_policy:
+          id: dependency_policy
+          title: Dependency Policy
+          description: Project should provide a dependencies policy that describes how dependencies are consumed and updated
+          passed: false
+        dependency_update_tool:
+          id: dependency_update_tool
+          title: Dependency Update Tool
+          description: This check tries to determine if the project uses a dependency update tool
+          passed: true
+        maintained:
+          id: maintained
+          title: Maintained
+          description: This check determines whether the project is actively maintained
+          passed: true
+        security_policy:
+          id: security_policy
+          title: Security Policy
+          description: Clearly documented security processes explaining how to report security issues
+          passed: true
+        signed_releases:
+          id: signed_releases
+          title: Signed Release
+          description: This check tries to determine if the project cryptographically signs release artifacts
+          passed: false
+        sbom:
+          id: sbom
+          title: Software Bill of Materials
+          description: List of components in a piece of software, including licenses, versions, etc.
+          passed: false
+        token_permissions:
+          id: token_permissions
+          title: Token Permissions
+          description: This check determines whether the project's automated workflow tokens are set to read-only by default
+          passed: false
+      legal:
+        trademark_disclaimer:
+          id: trademark_disclaimer
+          title: Trademark
+          description: A trademark should be applied to protect intellectual property
+          passed: false
 ---

--- a/exampleSite/content/fr/insights/ospo-utils.md
+++ b/exampleSite/content/fr/insights/ospo-utils.md
@@ -1,5 +1,5 @@
 ---
-title: ospo utils
+title: OSPO Utils
 description: A set of scripts to build ospo.ch
 params:
   org_name: ospo.ch

--- a/exampleSite/content/fr/insights/project-template.md
+++ b/exampleSite/content/fr/insights/project-template.md
@@ -1,5 +1,5 @@
 ---
-title: ospo project template
+title: OSPO Project Template
 description: A repository template for ospo.ch projects
 params:
   org_name: ospo.ch

--- a/exampleSite/content/fr/insights/project-template.md
+++ b/exampleSite/content/fr/insights/project-template.md
@@ -179,7 +179,7 @@ params:
           id: token_permissions
           title: Token Permissions
           description: This check determines whether the project’s automated workflows tokens are set to read-only by default.
-          passed:
+          passed: false
       legal:
         trademark_disclaimer:
           id: trademark_disclaimer

--- a/exampleSite/content/fr/projects/_index.md
+++ b/exampleSite/content/fr/projects/_index.md
@@ -1,3 +1,5 @@
 ---
-title: Projects
+title: Projets
 ---
+
+Découvrez les projets open source actifs développés et maintenus par ospo.ch, des thèmes Hugo aux outils d'automatisation et aux listes de ressources sélectionnées.

--- a/exampleSite/content/fr/projects/awesome-codeswissgov.md
+++ b/exampleSite/content/fr/projects/awesome-codeswissgov.md
@@ -1,7 +1,17 @@
 ---
-title: codeswissgov
-description: A curated list of OSS by Swiss Authorities
+title: Awesome CodeSwissGov
+description: Une liste sélectionnée de logiciels open source des autorités publiques suisses
 params:
   org_name: ospo.ch
   repository: https://github.com/ospo-ch/awesome-codeswissgov
 ---
+
+Awesome CodeSwissGov est une liste maintenue par la communauté regroupant les projets open source publiés par les autorités fédérales et cantonales suisses. Elle suit le format des [listes awesome](https://github.com/sindresorhus/awesome) et est mise à jour au fur et à mesure que de nouveaux dépôts sont identifiés.
+
+## Objectif
+
+Les autorités publiques suisses sont tenues, en vertu de la loi fédérale sur l'utilisation des moyens électroniques pour l'accomplissement des tâches des autorités (LMETA), de publier en open source les logiciels qu'elles développent, dans la mesure du possible. Cette liste permet de rendre ces publications découvrables en un seul endroit.
+
+## Contribuer
+
+Pour ajouter un projet, ouvrez une pull request sur le dépôt avec un lien, une courte description et l'autorité publique concernée. Les projets doivent être accessibles publiquement et maintenus par ou pour une entité publique suisse.

--- a/exampleSite/content/fr/projects/ospo-hugo-theme.md
+++ b/exampleSite/content/fr/projects/ospo-hugo-theme.md
@@ -1,7 +1,21 @@
 ---
-title: ospo theme
-description: A theme for the Hugo CMS to launch an ospo
+title: OSPO Hugo Theme
+description: Un thème pour le CMS Hugo permettant de lancer un OSPO
 params:
   org_name: ospo.ch
   repository: https://github.com/ospo-ch/ospo-hugo-theme
 ---
+
+Le thème OSPO Hugo fournit un site web clé en main pour les organisations gérant un Open Source Program Office. Basé sur [Hugo](https://gohugo.io), il inclut un catalogue logiciel, des pages de projets, des rapports d'évaluation et une prise en charge multilingue dès l'installation.
+
+## Fonctionnalités
+
+- **Catalogue logiciel** — listez et décrivez les outils open source utilisés ou maintenus par votre organisation
+- **Projets** — mettez en avant les projets open source actifs avec leurs liens de dépôt et leur statut
+- **Évaluation** — publiez des scores de santé automatisés couvrant la documentation, les licences, la sécurité et les bonnes pratiques
+- **Multilingue** — anglais et français pris en charge ; ajoutez d'autres langues via le système i18n de Hugo
+- **Section documentation** — rédigez des guides et des politiques en Markdown standard avec alertes, tableaux et coloration syntaxique
+
+## Statut
+
+En développement actif, utilisé pour [ospo.ch](https://ospo.ch). Les contributions sont les bienvenues via le dépôt.

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -16,7 +16,7 @@ build:
 taxonomies:
   category: "categories"
   tag: "tags"
-  languages: "languages"
+  prog_language: "prog_languages"
 
 markup:
   goldmark:

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,17 +21,13 @@
           <ul class="social-links">
             {{ range . }}
             <li>
-<<<<<<< HEAD
-                <a href="{{ .url }}" aria-label="{{ humanize .key }}" rel="noopener noreferrer" target="_blank">
-=======
                 <a href="{{ .url }}">
->>>>>>> 1cce2b2 (fix: Remove empty title attribute from footer social links)
                     <img loading="lazy" width="20" height="20" src="{{ printf "images/icons/%s.svg" .key | relURL }}" alt="{{ (humanize .key) | safeHTMLAttr }} icon">
                 </a>
             </li>
             {{ end }}
           </ul>
-        {{ end }}
+        {{ end }}s
       {{ end }}
     </div>
   </div>

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -1,0 +1,26 @@
+{{ define "main" }}
+<div class="main-wrapper">
+  <div class="main-area">
+    <article>
+      <header class="project-header">
+        <p class="project-header__org">{{ .Params.org_name }}</p>
+        <h1 class="project-header__title">{{ .Title }}</h1>
+        {{- with .Description }}
+        <p class="project-header__description">{{ . }}</p>
+        {{- end }}
+        <div class="project-header__links">
+          {{- with .Params.repository }}
+          <a href="{{ . }}" class="button button--secondary" target="_blank" rel="noopener noreferrer">Repository</a>
+          {{- end }}
+          {{- with .Params.website }}
+          <a href="{{ . }}" class="button button--secondary" target="_blank" rel="noopener noreferrer">Website</a>
+          {{- end }}
+        </div>
+      </header>
+      {{- with .Content }}
+      <div class="project-body">{{ . }}</div>
+      {{- end }}
+    </article>
+  </div>
+</div>
+{{ end }}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -10,10 +10,10 @@
         {{- end }}
         <div class="project-header__links">
           {{- with .Params.repository }}
-          <a href="{{ . }}" class="button button--secondary" target="_blank" rel="noopener noreferrer">Repository</a>
+          <a href="{{ . }}" class="button button" target="_blank" rel="noopener noreferrer">Repository</a>
           {{- end }}
           {{- with .Params.website }}
-          <a href="{{ . }}" class="button button--secondary" target="_blank" rel="noopener noreferrer">Website</a>
+          <a href="{{ . }}" class="button button" target="_blank" rel="noopener noreferrer">Website</a>
           {{- end }}
         </div>
       </header>


### PR DESCRIPTION
- **feat: Add projects/single.html detail layout**
- **fix: Set explicit passed: false for token_permissions audit**
- **feat: Add French accessibility statement**
- **feat: Add French writing-content docs page**
- **fix: Localize French homepage button labels**
- **content: Add intro paragraphs to section landing pages (EN+FR)**
- **content: Populate project detail bodies (EN+FR)**
- **content: Populate catalog detail bodies (EN+FR)**
- **content: Add Getting Started sub-pages: Installation and Configuration (EN+FR)**
- **content: Add taxonomies to catalog items and rename languages → prog_languages**
- **content: Demonstrate syntax highlighting in writing-content (EN+FR)**
- **content: Add repositories audit detail to ospo-theme insights report (EN+FR)**
- **content: Trim filler table rows in writing-content (EN+FR)**
- **content: Dedupe home page copy and fix title casing (EN+FR)**
- **content: Extend Markdown showcase with headings, hr, task lists, images (EN+FR)**
- **docs: Document the button shortcode and fix non-existent CSS class**
- **fix: resolve merge conflict in footer.html**
- **fix: resolve merge conflict in accordion.js**
